### PR TITLE
refactor(sre-assistant): 統一工具的 HTTP 客戶端並修復測試

### DIFF
--- a/services/sre-assistant/tests/test_workflow.py
+++ b/services/sre-assistant/tests/test_workflow.py
@@ -4,6 +4,7 @@ SRE 工作流程測試 (已重構以匹配目前的實作)
 
 import pytest
 import uuid
+import httpx
 from unittest.mock import Mock, AsyncMock, patch
 
 from sre_assistant.workflow import SREWorkflow
@@ -50,10 +51,17 @@ def mock_redis_client():
     return client, redis_store
 
 @pytest.fixture
-def workflow(mock_config, mock_redis_client):
+def http_client():
+    """提供一個 httpx.AsyncClient 實例"""
+    # 根據交接建議，直接回傳實例，而不是使用 async generator
+    return httpx.AsyncClient()
+
+@pytest.fixture
+def workflow(mock_config, mock_redis_client, http_client):
     """建立一個帶有模擬依賴的工作流程實例"""
     redis_client, _ = mock_redis_client
-    return SREWorkflow(mock_config, redis_client)
+    # 將共享的 http_client 注入
+    return SREWorkflow(mock_config, redis_client, http_client)
 
 
 @pytest.mark.asyncio

--- a/services/sre-assistant/tests/tools/test_loki_tool.py
+++ b/services/sre-assistant/tests/tools/test_loki_tool.py
@@ -19,9 +19,14 @@ def mock_config():
     return config
 
 @pytest.fixture
-def loki_tool(mock_config):
+def http_client():
+    """提供一個 httpx.AsyncClient 實例"""
+    return httpx.AsyncClient(base_url=BASE_URL)
+
+@pytest.fixture
+def loki_tool(mock_config, http_client):
     """初始化 LokiLogQueryTool"""
-    return LokiLogQueryTool(mock_config)
+    return LokiLogQueryTool(mock_config, http_client)
 
 @pytest.mark.asyncio
 @respx.mock

--- a/services/sre-assistant/tests/tools/test_prometheus_tool.py
+++ b/services/sre-assistant/tests/tools/test_prometheus_tool.py
@@ -41,10 +41,16 @@ def mock_redis_client():
     return client, redis_store
 
 @pytest.fixture
-def prometheus_tool(mock_config, mock_redis_client):
+def http_client():
+    """提供一個 httpx.AsyncClient 實例"""
+    return httpx.AsyncClient(base_url=BASE_URL)
+
+@pytest.fixture
+def prometheus_tool(mock_config, http_client, mock_redis_client):
     """初始化 PrometheusQueryTool 並注入模擬的 Redis 客戶端"""
     redis_client, _ = mock_redis_client
-    tool = PrometheusQueryTool(mock_config, redis_client)
+    # 注入共享的 http_client
+    tool = PrometheusQueryTool(mock_config, http_client, redis_client)
     return tool
 
 @pytest.mark.asyncio


### PR DESCRIPTION
根據 ROADMAP.md 中的架構改進目標，對 SRE Assistant 中的所有 Python 工具 (`PrometheusQueryTool`, `LokiLogQueryTool`, `ControlPlaneTool`) 進行了重構。

主要的變更包括：
- 修改所有工具的建構函式，使其能夠接收並使用一個共享的 `httpx.AsyncClient` 實例，而不是在每次請求時都建立新的客戶端。
- 更新 `SREWorkflow` 以便在初始化時將共享的 `http_client` 注入到所有工具中。
- 修正了 `services/sre-assistant/tests/` 下的所有相關單元測試，為工具的初始化提供了模擬的 `http_client`，並解決了因此產生的測試失敗問題。

這項變更從根本上提升了服務的效率和韌性，並確保了測試套件的穩定性。