### PR TITLE
refactor: align identity modals with UX spec

### DIFF
--- a/frontend/src/components/EditUserModal.tsx
+++ b/frontend/src/components/EditUserModal.tsx
@@ -1,8 +1,23 @@
-import React, { useEffect } from 'react';
-import { Modal, Form, Input, Button, message, Select, Spin } from 'antd';
+import React, { useEffect, useMemo } from 'react';
+import {
+  Alert,
+  Col,
+  Descriptions,
+  Divider,
+  Form,
+  Row,
+  Select,
+  Space,
+  Spin,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from 'antd';
 import api from '../services/api';
 import { useTeams } from '../hooks/useTeams';
 import { useRoles } from '../hooks/useRoles';
+import { GlassModal } from './GlassModal';
 
 type UserRecord = {
   id: string;
@@ -28,6 +43,16 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ open, user, onCancel, onS
   const { teams, loading: teamsLoading } = useTeams();
   const { roles, loading: rolesLoading } = useRoles();
 
+  const teamOptions = useMemo(
+    () => teams.map((team) => ({ label: team.name, value: team.id })),
+    [teams],
+  );
+
+  const roleOptions = useMemo(
+    () => roles.map((role) => ({ label: role.name, value: role.id })),
+    [roles],
+  );
+
   useEffect(() => {
     if (user) {
       form.setFieldsValue({
@@ -36,6 +61,8 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ open, user, onCancel, onS
         roles: user.roles,
         teams: user.teams,
       });
+    } else {
+      form.resetFields();
     }
   }, [user, form]);
 
@@ -43,69 +70,186 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ open, user, onCancel, onS
     if (!user) return;
     setLoading(true);
     try {
-      // @ts-ignore - api.updateUser is not defined yet
       await api.updateUser(user.id, {
         role_ids: values.roles,
         team_ids: values.teams,
       });
       message.success(`使用者 ${user.name} 的權限已更新`);
       onSuccess();
-    } catch (error) {
+    } catch {
       message.error('更新失敗，請稍後再試');
     } finally {
       setLoading(false);
     }
   };
 
+  const selectedRoles = Form.useWatch('roles', form) as string[] | undefined;
+  const selectedTeams = Form.useWatch('teams', form) as string[] | undefined;
+
+  const selectedRoleBadges = useMemo(
+    () => (selectedRoles || []).map((roleId) => {
+      const role = roles.find((item) => item.id === roleId);
+      return (
+        <Tag key={roleId} color="blue" style={{ marginBottom: 4 }}>
+          {role?.name ?? roleId}
+        </Tag>
+      );
+    }),
+    [roles, selectedRoles],
+  );
+
+  const selectedTeamBadges = useMemo(
+    () => (selectedTeams || []).map((teamId) => {
+      const team = teams.find((item) => item.id === teamId);
+      return (
+        <Tag key={teamId} color="purple" style={{ marginBottom: 4 }}>
+          {team?.name ?? teamId}
+        </Tag>
+      );
+    }),
+    [teams, selectedTeams],
+  );
+
+  const handleCancel = () => {
+    form.resetFields();
+    onCancel();
+  };
+
   return (
-    <Modal
-      title="編輯人員權限"
+    <GlassModal
       open={open}
-      onCancel={onCancel}
-      footer={[
-        <Button key="back" onClick={onCancel}>
-          取消
-        </Button>,
-        <Button key="submit" type="primary" loading={loading} onClick={() => form.submit()}>
-          儲存變更
-        </Button>,
-      ]}
+      onCancel={handleCancel}
+      onOk={() => form.submit()}
+      okText="儲存變更"
+      cancelText="取消"
+      confirmLoading={loading}
+      title={(
+        <Space direction="vertical" size={2} style={{ width: '100%' }}>
+          <Typography.Title level={4} style={{ color: 'var(--text-primary)', marginBottom: 0 }}>
+            編輯人員權限
+          </Typography.Title>
+          {user ? (
+            <Typography.Text type="secondary">
+              {user.name} · {user.email}
+            </Typography.Text>
+          ) : null}
+        </Space>
+      )}
+      width={720}
     >
       {user ? (
-        <Form form={form} layout="vertical" onFinish={handleUpdate} requiredMark={false}>
-          <Form.Item name="name" label="姓名">
-            <Input readOnly disabled />
-          </Form.Item>
-          <Form.Item name="email" label="電子郵件">
-            <Input readOnly disabled />
-          </Form.Item>
-          <Form.Item name="roles" label="角色">
-            <Select
-              mode="multiple"
-              loading={rolesLoading}
-              placeholder="請選擇角色"
-              options={roles.map((role: any) => ({
-                label: role.name,
-                value: role.id,
-              }))}
-            />
-          </Form.Item>
-          <Form.Item name="teams" label="團隊">
-            <Select
-              mode="multiple"
-              loading={teamsLoading}
-              placeholder="請選擇團隊"
-              options={teams.map((team: any) => ({
-                label: team.name,
-                value: team.id,
-              }))}
-            />
-          </Form.Item>
-        </Form>
+        <Space direction="vertical" size="large" style={{ width: '100%' }}>
+          <Alert
+            type="info"
+            showIcon
+            message="資料來源"
+            description="姓名與電子郵件由身份提供商管理，僅供檢視。如需修改，請至 Keycloak 後台。"
+          />
+
+          <div style={{ border: '1px solid rgba(255, 255, 255, 0.08)', borderRadius: 12, padding: 16 }}>
+            <Space direction="vertical" style={{ width: '100%' }} size="middle">
+              <Space align="center" size="small">
+                <Typography.Title level={5} style={{ margin: 0 }}>基本資訊</Typography.Title>
+                <Tag color="geekblue">SSO · Keycloak</Tag>
+              </Space>
+              <Descriptions
+                size="small"
+                column={1}
+                colon={false}
+                labelStyle={{ width: 96, color: 'var(--text-tertiary)' }}
+                contentStyle={{ color: 'var(--text-primary)' }}
+              >
+                <Descriptions.Item
+                  label={(
+                    <Tooltip title="此資訊由 SSO 同步，無法在此編輯">
+                      <span>姓名</span>
+                    </Tooltip>
+                  )}
+                >
+                  <Typography.Text strong>{user.name}</Typography.Text>
+                </Descriptions.Item>
+                <Descriptions.Item
+                  label={(
+                    <Tooltip title="此資訊由 SSO 同步，無法在此編輯">
+                      <span>電子郵件</span>
+                    </Tooltip>
+                  )}
+                >
+                  <Typography.Text>{user.email}</Typography.Text>
+                </Descriptions.Item>
+              </Descriptions>
+            </Space>
+          </div>
+
+          <Divider orientation="left" style={{ borderColor: 'rgba(255, 255, 255, 0.1)' }}>
+            <Typography.Text strong>權限設定</Typography.Text>
+          </Divider>
+
+          <Form form={form} layout="vertical" onFinish={handleUpdate} requiredMark={false}>
+            <Row gutter={16}>
+              <Col span={12}>
+                <Form.Item
+                  name="roles"
+                  label="角色"
+                  rules={[{ required: true, message: '請至少選擇一個角色' }]}
+                >
+                  <Select
+                    mode="multiple"
+                    loading={rolesLoading}
+                    placeholder="請選擇角色"
+                    options={roleOptions}
+                    optionFilterProp="label"
+                  />
+                </Form.Item>
+              </Col>
+              <Col span={12}>
+                <Form.Item
+                  name="teams"
+                  label="所屬團隊"
+                  rules={[{ required: true, message: '請至少選擇一個團隊' }]}
+                >
+                  <Select
+                    mode="multiple"
+                    loading={teamsLoading}
+                    placeholder="請選擇團隊"
+                    options={teamOptions}
+                    optionFilterProp="label"
+                  />
+                </Form.Item>
+              </Col>
+            </Row>
+          </Form>
+
+          <div
+            style={{
+              border: '1px solid rgba(255, 255, 255, 0.08)',
+              borderRadius: 12,
+              padding: 16,
+              background: 'rgba(255, 255, 255, 0.02)',
+            }}
+          >
+            <Space direction="vertical" size="small" style={{ width: '100%' }}>
+              <Typography.Text strong>變更預覽</Typography.Text>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                儲存後將套用以下角色與團隊映射，後端會產生審計日誌以供追蹤。
+              </Typography.Text>
+              <Space direction="vertical" size="small">
+                <Typography.Text type="secondary">角色</Typography.Text>
+                <Space wrap>{selectedRoleBadges.length > 0 ? selectedRoleBadges : <Tag color="default">尚未選擇角色</Tag>}</Space>
+              </Space>
+              <Space direction="vertical" size="small">
+                <Typography.Text type="secondary">所屬團隊</Typography.Text>
+                <Space wrap>{selectedTeamBadges.length > 0 ? selectedTeamBadges : <Tag color="default">尚未選擇團隊</Tag>}</Space>
+              </Space>
+            </Space>
+          </div>
+        </Space>
       ) : (
-        <Spin />
+        <div style={{ padding: 48, textAlign: 'center' }}>
+          <Spin />
+        </div>
       )}
-    </Modal>
+    </GlassModal>
   );
 };
 

--- a/frontend/src/components/GlassModal.tsx
+++ b/frontend/src/components/GlassModal.tsx
@@ -6,11 +6,22 @@ import type { ModalProps } from 'antd';
  * 樣式由 global.css 中的 .platform-modal class 控制。
  * 這個組件封裝了 Ant Design 的 Modal，並透過 wrapClassName 應用了全域的玻璃效果樣式。
  */
-export const GlassModal = (props: ModalProps) => (
+export const GlassModal = ({
+  wrapClassName,
+  width,
+  centered,
+  destroyOnClose,
+  maskClosable,
+  ...restProps
+}: ModalProps) => (
   <Modal
-    {...props}
+    {...restProps}
+    width={width ?? 720}
+    centered={centered ?? true}
+    destroyOnClose={destroyOnClose ?? true}
+    maskClosable={maskClosable ?? false}
     // 使用 wrapClassName 將樣式應用到 Modal 的最外層容器
-    wrapClassName={`platform-modal ${props.wrapClassName || ''}`}
+    wrapClassName={`platform-modal ${wrapClassName || ''}`.trim()}
   />
 );
 

--- a/frontend/src/components/InviteUserModal.tsx
+++ b/frontend/src/components/InviteUserModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Modal, Form, Input, Button, message } from 'antd';
-import { MailOutlined } from '@ant-design/icons';
+import { Alert, Form, Input, Space, Typography, message } from 'antd';
+import { MailOutlined, UserOutlined } from '@ant-design/icons';
 import api from '../services/api';
+import { GlassModal } from './GlassModal';
 
 interface InviteUserModalProps {
   open: boolean;
@@ -9,19 +10,43 @@ interface InviteUserModalProps {
   onSuccess: () => void;
 }
 
+type InviteUserFormValues = {
+  email: string;
+  lastName: string;
+  firstName: string;
+  note?: string;
+};
+
 const InviteUserModal: React.FC<InviteUserModalProps> = ({ open, onCancel, onSuccess }) => {
-  const [form] = Form.useForm();
+  const [form] = Form.useForm<InviteUserFormValues>();
   const [loading, setLoading] = React.useState(false);
 
-  const handleInvite = async (values: { email: string }) => {
+  const handleClose = React.useCallback(() => {
+    form.resetFields();
+    onCancel();
+  }, [form, onCancel]);
+
+  const handleInvite = async (values: InviteUserFormValues) => {
     setLoading(true);
     try {
-      // @ts-ignore - api.inviteUser is not defined yet
-      await api.inviteUser(values.email);
-      message.success(`邀請已成功發送至 ${values.email}`);
+      const payload = {
+        email: values.email.trim().toLowerCase(),
+        first_name: values.firstName.trim(),
+        last_name: values.lastName.trim(),
+        note: values.note?.trim() || undefined,
+      };
+
+      if (!payload.first_name || !payload.last_name) {
+        message.error('請完整輸入姓名資訊');
+        setLoading(false);
+        return;
+      }
+
+      await api.inviteUser(payload);
+      message.success(`已向 ${payload.email} 發送邀請郵件`);
       onSuccess();
       form.resetFields();
-    } catch (error) {
+    } catch {
       message.error('邀請失敗，請稍後再試');
     } finally {
       setLoading(false);
@@ -29,32 +54,84 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ open, onCancel, onSuc
   };
 
   return (
-    <Modal
-      title="邀請新人員"
+    <GlassModal
       open={open}
-      onCancel={onCancel}
-      footer={[
-        <Button key="back" onClick={onCancel}>
-          取消
-        </Button>,
-        <Button key="submit" type="primary" loading={loading} onClick={() => form.submit()}>
-          發送邀請
-        </Button>,
-      ]}
+      onCancel={handleClose}
+      onOk={() => form.submit()}
+      okText="發送邀請"
+      cancelText="取消"
+      confirmLoading={loading}
+      title={(
+        <Space direction="vertical" size={2} style={{ width: '100%' }}>
+          <Typography.Title level={4} style={{ color: 'var(--text-primary)', marginBottom: 0 }}>
+            邀請新人員
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            透過 Keycloak 發送設定密碼的邀請郵件
+          </Typography.Text>
+        </Space>
+      )}
+      width={600}
     >
-      <Form form={form} layout="vertical" onFinish={handleInvite} requiredMark={false}>
-        <Form.Item
-          name="email"
-          label="電子郵件地址"
-          rules={[
-            { required: true, message: '請輸入電子郵件地址' },
-            { type: 'email', message: '請輸入有效的電子郵件地址' },
-          ]}
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Alert
+          showIcon
+          type="info"
+          message="身份提供商管理"
+          description="此流程會透過 Keycloak 建立帳號，並寄送設定密碼的安全連結。姓名與電子郵件將以 SSO 為唯一真實來源。"
+        />
+
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleInvite}
+          requiredMark={false}
         >
-          <Input prefix={<MailOutlined />} placeholder="e.g., user@example.com" />
-        </Form.Item>
-      </Form>
-    </Modal>
+          <Form.Item
+            name="email"
+            label="電子郵件"
+            rules={[
+              { required: true, message: '請輸入電子郵件' },
+              { type: 'email', message: '請輸入有效的電子郵件' },
+            ]}
+          >
+            <Input prefix={<MailOutlined />} placeholder="user@example.com" autoComplete="email" />
+          </Form.Item>
+
+          <Space direction="horizontal" size="large" style={{ width: '100%' }}>
+            <Form.Item
+              name="lastName"
+              label="姓氏"
+              rules={[{ required: true, message: '請輸入姓氏' }]}
+              style={{ flex: 1 }}
+            >
+              <Input prefix={<UserOutlined />} placeholder="例如：林" autoComplete="family-name" />
+            </Form.Item>
+            <Form.Item
+              name="firstName"
+              label="名字"
+              rules={[{ required: true, message: '請輸入名字' }]}
+              style={{ flex: 1 }}
+            >
+              <Input prefix={<UserOutlined />} placeholder="例如：奕辰" autoComplete="given-name" />
+            </Form.Item>
+          </Space>
+
+          <Form.Item
+            name="note"
+            label="邀請訊息（選填）"
+            tooltip="此訊息會附加在邀請郵件中，協助受邀者了解用途"
+          >
+            <Input.TextArea
+              rows={3}
+              placeholder="向新成員說明加入的目的或責任範圍"
+              maxLength={280}
+              showCount
+            />
+          </Form.Item>
+        </Form>
+      </Space>
+    </GlassModal>
   );
 };
 

--- a/frontend/src/components/RoleFormModal.tsx
+++ b/frontend/src/components/RoleFormModal.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { Modal, Form, Input, Button, message, Typography } from 'antd';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Form, Input, Space, Tag, Typography, message } from 'antd';
 import api from '../services/api';
 import PermissionTreeSelector from './PermissionTreeSelector';
+import { GlassModal } from './GlassModal';
 
 type Role = {
   id: string;
@@ -21,6 +22,7 @@ interface RoleFormModalProps {
 const RoleFormModal: React.FC<RoleFormModalProps> = ({ open, role, onCancel, onSuccess }) => {
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
+  const [permissionSearch, setPermissionSearch] = useState('');
 
   useEffect(() => {
     if (open) {
@@ -29,85 +31,174 @@ const RoleFormModal: React.FC<RoleFormModalProps> = ({ open, role, onCancel, onS
       } else {
         form.resetFields();
       }
+      setPermissionSearch('');
     }
   }, [role, open, form]);
 
   const handleSubmit = async (values: { name: string; description: string; permissions: string[] }) => {
     setLoading(true);
     try {
+      const trimmedName = values.name.trim();
+      const sanitizedDescription = values.description?.trim() ?? '';
+      const uniquePermissions = Array.isArray(values.permissions)
+        ? Array.from(new Set(values.permissions))
+        : [];
+
+      if (!trimmedName) {
+        message.error('請輸入角色名稱');
+        setLoading(false);
+        return;
+      }
+
+      const payload = {
+        name: trimmedName,
+        description: sanitizedDescription,
+        permissions: uniquePermissions,
+      };
+
       if (role) {
-        // @ts-ignore
-        await api.updateRole(role.id, values);
-        message.success(`角色 ${values.name} 已更新`);
+        await api.updateRole(role.id, payload);
+        message.success(`角色 ${trimmedName} 已更新`);
       } else {
-        // @ts-ignore
-        await api.createRole(values);
-        message.success(`角色 ${values.name} 已建立`);
+        await api.createRole(payload);
+        message.success(`角色 ${trimmedName} 已建立`);
       }
       onSuccess();
-    } catch (error) {
+    } catch {
       message.error('操作失敗，請稍後再試');
     } finally {
       setLoading(false);
     }
   };
 
+  const selectedPermissions = Form.useWatch('permissions', form) as string[] | undefined;
+  const permissionPreview = useMemo(() => {
+    const list = selectedPermissions ?? [];
+    const preview = list.slice(0, 10);
+    const remaining = list.length - preview.length;
+
+    return {
+      previewTags: preview.map((permission) => (
+        <Tag key={permission} color="blue" style={{ marginBottom: 4 }}>
+          {permission}
+        </Tag>
+      )),
+      remaining,
+    };
+  }, [selectedPermissions]);
+
+  const handleCancel = () => {
+    form.resetFields();
+    setPermissionSearch('');
+    onCancel();
+  };
+
   return (
-    <Modal
-      title={role ? '編輯角色' : '新增角色'}
+    <GlassModal
       open={open}
-      onCancel={onCancel}
-      footer={[
-        <Button key="back" onClick={onCancel}>
-          取消
-        </Button>,
-        <Button key="submit" type="primary" loading={loading} onClick={() => form.submit()}>
-          {role ? '儲存變更' : '建立角色'}
-        </Button>,
-      ]}
-    >
-      <Form form={form} layout="vertical" onFinish={handleSubmit} requiredMark={false}>
-        <Form.Item
-          name="name"
-          label="角色名稱"
-          rules={[{ required: true, message: '請輸入角色名稱' }]}
-        >
-          <Input
-            placeholder="例如：SRE 工程師"
-            disabled={role?.is_built_in}
-          />
-        </Form.Item>
-
-        <Form.Item
-          name="description"
-          label="角色描述"
-        >
-          <Input.TextArea
-            rows={2}
-            placeholder="描述這個角色的職責和權限範圍"
-            disabled={role?.is_built_in}
-          />
-        </Form.Item>
-
-        <Form.Item
-          name="permissions"
-          label="權限配置"
-          rules={[{ required: true, message: '請至少選擇一個權限' }]}
-        >
-          <PermissionTreeSelector
-            value={form.getFieldValue('permissions')}
-            onChange={(permissions) => form.setFieldsValue({ permissions })}
-            disabled={role?.is_built_in}
-          />
-        </Form.Item>
-
-        {role?.is_built_in && (
-          <Typography.Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
-            ℹ️ 內建角色無法修改，如需自訂權限請建立新角色
+      onCancel={handleCancel}
+      onOk={() => form.submit()}
+      okText={role ? '儲存變更' : '建立角色'}
+      cancelText="取消"
+      confirmLoading={loading}
+      title={(
+        <Space direction="vertical" size={2} style={{ width: '100%' }}>
+          <Typography.Title level={4} style={{ color: 'var(--text-primary)', marginBottom: 0 }}>
+            {role ? '編輯角色' : '新增角色'}
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            組合權限為可重用的角色範本，所有調整皆會寫入審計日誌
           </Typography.Text>
-        )}
-      </Form>
-    </Modal>
+        </Space>
+      )}
+      width={760}
+    >
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Alert
+          showIcon
+          type="info"
+          message="權限即程式碼"
+          description="角色定義應與後端權限碼保持一致，建議先複製現有角色再調整，以維持權限治理的一致性。"
+        />
+
+        <Form form={form} layout="vertical" onFinish={handleSubmit} requiredMark={false}>
+          <Form.Item
+            name="name"
+            label="角色名稱"
+            rules={[{ required: true, message: '請輸入角色名稱' }]}
+          >
+            <Input
+              placeholder="例如：SRE 工程師"
+              disabled={role?.is_built_in}
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="description"
+            label="角色描述"
+          >
+            <Input.TextArea
+              rows={2}
+              placeholder="描述這個角色的職責和權限範圍"
+              disabled={role?.is_built_in}
+            />
+          </Form.Item>
+
+          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+            <Input.Search
+              value={permissionSearch}
+              onChange={(event) => setPermissionSearch(event.target.value)}
+              placeholder="搜尋權限名稱或代碼，例如 incidents:update"
+              allowClear
+              disabled={role?.is_built_in}
+            />
+
+            <Form.Item
+              name="permissions"
+              label="權限配置"
+              rules={[{ required: true, message: '請至少選擇一個權限' }]}
+            >
+              <PermissionTreeSelector
+                value={form.getFieldValue('permissions')}
+                onChange={(permissions) => form.setFieldsValue({ permissions })}
+                disabled={role?.is_built_in}
+                searchValue={permissionSearch}
+              />
+            </Form.Item>
+          </Space>
+
+          {role?.is_built_in && (
+            <Typography.Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
+              ℹ️ 內建角色無法修改，如需自訂權限請建立新角色
+            </Typography.Text>
+          )}
+        </Form>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            borderRadius: 12,
+            padding: 16,
+            background: 'rgba(255, 255, 255, 0.02)',
+          }}
+        >
+          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+            <Typography.Text strong>權限摘要</Typography.Text>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              已選擇 {selectedPermissions?.length ?? 0} 項權限，將於儲存時同步至 RBAC 配置。
+            </Typography.Text>
+            <Space wrap>
+              {permissionPreview.previewTags.length > 0
+                ? permissionPreview.previewTags
+                : <Tag color="default">尚未選擇權限</Tag>}
+              {permissionPreview.remaining > 0 && (
+                <Tag color="geekblue">+{permissionPreview.remaining} 更多</Tag>
+              )}
+            </Space>
+          </Space>
+        </div>
+      </Space>
+    </GlassModal>
   );
 };
 

--- a/frontend/src/components/TeamFormModal.tsx
+++ b/frontend/src/components/TeamFormModal.tsx
@@ -1,9 +1,22 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Modal, Form, Input, Button, message, Transfer } from 'antd';
+import {
+  Alert,
+  Form,
+  Input,
+  Select,
+  Space,
+  Tabs,
+  Tag,
+  Typography,
+  message,
+  Transfer,
+} from 'antd';
+import type { TabsProps } from 'antd';
 import type { TransferItem } from 'antd/es/transfer';
 import api from '../services/api';
 import { useUsers } from '../hooks/useUsers';
 import type { User } from '../hooks/useUsers';
+import { GlassModal } from './GlassModal';
 
 type TeamRecord = {
   id: string;
@@ -11,6 +24,13 @@ type TeamRecord = {
   description?: string;
   member_count: number;
   members?: string[]; // 假設 API 回傳成員識別碼陣列
+  leader_id?: string | null;
+  subscribers?: string[];
+  responsibilities?: Array<{
+    type: string;
+    name: string;
+    identifier?: string;
+  }>;
 };
 
 interface TeamFormModalProps {
@@ -23,13 +43,17 @@ interface TeamFormModalProps {
 type TeamFormValues = {
   name: string;
   description?: string;
+  leader_id?: string;
   members: string[];
+  subscribers: string[];
 };
 
 type TeamPayload = {
   name: string;
   description?: string | null;
-  members: string[];
+  leader_id?: string | null;
+  member_ids: string[];
+  subscriber_emails: string[];
 };
 
 const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onSuccess }) => {
@@ -38,6 +62,8 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
   const { users, loading: usersLoading } = useUsers();
   const [targetMemberKeys, setTargetMemberKeys] = useState<string[]>([]);
   const [selectedMemberKeys, setSelectedMemberKeys] = useState<string[]>([]);
+  const leaderId = Form.useWatch('leader_id', form);
+  const subscriberList = Form.useWatch('subscribers', form) as string[] | undefined;
 
   const memberOptions: TransferItem[] = useMemo(() => {
     if (users.length === 0) {
@@ -82,17 +108,36 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
     form.setFieldsValue({
       name: team?.name ?? '',
       description: team?.description ?? '',
+      leader_id: team?.leader_id ?? undefined,
       members: initialMembers,
+      subscribers: team?.subscribers ?? [],
     });
     setTargetMemberKeys(initialMembers);
     setSelectedMemberKeys([]);
   }, [team, open, form]);
+
+  useEffect(() => {
+    if (leaderId && !targetMemberKeys.includes(leaderId)) {
+      const nextKeys = [...targetMemberKeys, leaderId];
+      setTargetMemberKeys(nextKeys);
+      form.setFieldsValue({ members: nextKeys });
+    }
+  }, [leaderId, targetMemberKeys, form]);
 
   const handleSubmit = async (values: TeamFormValues) => {
     setLoading(true);
     try {
       const trimmedName = values.name.trim();
       const sanitizedMembers = Array.isArray(values.members) ? Array.from(new Set(values.members)) : [];
+      const sanitizedSubscribers = Array.isArray(values.subscribers)
+        ? Array.from(
+            new Set(
+              values.subscribers
+                .map((item) => item.trim())
+                .filter((item) => item.length > 0),
+            ),
+          )
+        : [];
 
       if (!trimmedName) {
         message.error('請輸入團隊名稱');
@@ -103,7 +148,9 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
       const payload: TeamPayload = {
         name: trimmedName,
         description: values.description?.trim() ? values.description.trim() : null,
-        members: sanitizedMembers,
+        leader_id: values.leader_id ?? null,
+        member_ids: sanitizedMembers,
+        subscriber_emails: sanitizedSubscribers,
       };
       if (team) {
         await api.updateTeam(team.id, payload);
@@ -121,40 +168,62 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
     }
   };
 
-  return (
-    <Modal
-      title={team ? '編輯團隊' : '新增團隊'}
-      open={open}
-      onCancel={onCancel}
-      footer={[
-        <Button key="back" onClick={onCancel}>
-          取消
-        </Button>,
-        <Button key="submit" type="primary" loading={loading} onClick={() => form.submit()}>
-          {team ? '儲存變更' : '建立團隊'}
-        </Button>,
-      ]}
-    >
-      <Form form={form} layout="vertical" onFinish={handleSubmit} requiredMark={false}>
-        <Form.Item
-          name="name"
-          label="團隊名稱"
-          rules={[{ required: true, message: '請輸入團隊名稱' }]}
-        >
-          <Input placeholder="例如：SRE 核心團隊" />
-        </Form.Item>
-        <Form.Item
-          name="description"
-          label="描述"
-        >
-          <Input.TextArea rows={3} placeholder="請輸入團隊的職責或目標" />
-        </Form.Item>
+  const memberOptionMap = useMemo(() => {
+    const map = new Map<string, TransferItem>();
+    memberOptions.forEach((item) => {
+      map.set(String(item.key), item);
+    });
+    return map;
+  }, [memberOptions]);
+
+  const leaderOptions = useMemo(
+    () =>
+      targetMemberKeys.map((key) => {
+        const option = memberOptionMap.get(key);
+        return {
+          label: option?.title ?? key,
+          value: key,
+        };
+      }),
+    [memberOptionMap, targetMemberKeys],
+  );
+
+  const memberPreviewTags = useMemo(
+    () =>
+      targetMemberKeys.map((key) => {
+        const option = memberOptionMap.get(key);
+        return (
+          <Tag key={key} color="blue" style={{ marginBottom: 4 }}>
+            {option?.title ?? key}
+          </Tag>
+        );
+      }),
+    [memberOptionMap, targetMemberKeys],
+  );
+
+  const subscriberTags = useMemo(
+    () =>
+      (subscriberList || []).map((email) => (
+        <Tag key={email} color="purple" style={{ marginBottom: 4 }}>
+          {email}
+        </Tag>
+      )),
+    [subscriberList],
+  );
+
+  const responsibilities = team?.responsibilities ?? [];
+
+  const tabItems: TabsProps['items'] = [
+    {
+      key: 'members',
+      label: '核心成員',
+      children: (
         <Form.Item
           label="團隊成員"
           extra="右欄為已指派成員，可透過搜尋或箭頭快速移動"
         >
           <Form.Item name="members" hidden>
-            <Input type="hidden" />
+            <input type="hidden" />
           </Form.Item>
           <Transfer
             dataSource={memberOptions}
@@ -183,7 +252,7 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
               ),
               value: `${item.title}${item.description ? ` ${item.description}` : ''}`,
             })}
-            listStyle={{ width: '100%', minWidth: 220, height: 260 }}
+            listStyle={{ width: '100%', minWidth: 260, height: 280 }}
             style={{ width: '100%' }}
             locale={{
               itemUnit: '位',
@@ -200,8 +269,151 @@ const TeamFormModal: React.FC<TeamFormModalProps> = ({ open, team, onCancel, onS
             }}
           />
         </Form.Item>
-      </Form>
-    </Modal>
+      ),
+    },
+    {
+      key: 'subscribers',
+      label: '通知訂閱者',
+      children: (
+        <Form.Item
+          name="subscribers"
+          label="訂閱者電子郵件"
+          tooltip="訂閱者會接收與此團隊相關的通知，但不具備操作權限"
+        >
+          <Select
+            mode="tags"
+            placeholder="輸入或貼上電子郵件，按 Enter 建立"
+            tokenSeparators={[',', ';', ' ']}
+            open={false}
+          />
+        </Form.Item>
+      ),
+    },
+  ];
+
+  const handleCancel = () => {
+    form.resetFields();
+    onCancel();
+  };
+
+  return (
+    <GlassModal
+      open={open}
+      onCancel={handleCancel}
+      onOk={() => form.submit()}
+      okText={team ? '儲存變更' : '建立團隊'}
+      cancelText="取消"
+      confirmLoading={loading}
+      title={(
+        <Space direction="vertical" size={2} style={{ width: '100%' }}>
+          <Typography.Title level={4} style={{ color: 'var(--text-primary)', marginBottom: 0 }}>
+            {team ? '編輯團隊' : '新增團隊'}
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            定義團隊負責範圍，並建立成員與通知映射
+          </Typography.Text>
+        </Space>
+      )}
+      width={840}
+    >
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Alert
+          showIcon
+          type="info"
+          message="團隊即問責"
+          description="團隊是連結資源、事件與通知的核心樞紐。請同時指定負責人、核心成員與需要被動接收通知的訂閱者。"
+        />
+
+        <Form form={form} layout="vertical" onFinish={handleSubmit} requiredMark={false}>
+          <Space direction="vertical" size="large" style={{ width: '100%' }}>
+            <Space direction="horizontal" size="large" style={{ width: '100%', flexWrap: 'wrap' }}>
+              <Form.Item
+                name="name"
+                label="團隊名稱"
+                rules={[{ required: true, message: '請輸入團隊名稱' }]}
+                style={{ flex: '1 1 260px' }}
+              >
+                <Input placeholder="例如：SRE 核心團隊" />
+              </Form.Item>
+
+              <Form.Item
+                name="leader_id"
+                label="負責人"
+                rules={[{ required: true, message: '請選擇團隊負責人' }]}
+                style={{ flex: '1 1 220px' }}
+              >
+                <Select
+                  placeholder="從成員中選擇負責人"
+                  options={leaderOptions}
+                  loading={usersLoading}
+                  showSearch
+                  optionFilterProp="label"
+                />
+              </Form.Item>
+            </Space>
+
+            <Form.Item
+              name="description"
+              label="團隊職責描述"
+            >
+              <Input.TextArea rows={3} placeholder="描述團隊的目標、排班或負責範圍" />
+            </Form.Item>
+
+            <Tabs defaultActiveKey="members" items={tabItems} />
+          </Space>
+        </Form>
+
+        <div
+          style={{
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            borderRadius: 12,
+            padding: 16,
+            background: 'rgba(255, 255, 255, 0.02)',
+          }}
+        >
+          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <Typography.Text strong>設定預覽</Typography.Text>
+            <Space direction="vertical" size="small">
+              <Typography.Text type="secondary">負責人</Typography.Text>
+              <Tag color="geekblue">{leaderOptions.find((option) => option.value === leaderId)?.label ?? '尚未選擇負責人'}</Tag>
+            </Space>
+            <Space direction="vertical" size="small">
+              <Typography.Text type="secondary">核心成員</Typography.Text>
+              <Space wrap>{memberPreviewTags.length > 0 ? memberPreviewTags : <Tag>尚未指派成員</Tag>}</Space>
+            </Space>
+            <Space direction="vertical" size="small">
+              <Typography.Text type="secondary">通知訂閱者</Typography.Text>
+              <Space wrap>{subscriberTags.length > 0 ? subscriberTags : <Tag>尚未設定訂閱者</Tag>}</Space>
+            </Space>
+          </Space>
+        </div>
+
+        <div
+          style={{
+            border: '1px dashed rgba(255, 255, 255, 0.12)',
+            borderRadius: 12,
+            padding: 16,
+          }}
+        >
+          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+            <Typography.Text strong>責任範圍</Typography.Text>
+            {responsibilities.length > 0 ? (
+              <Space direction="vertical" size={4}>
+                {responsibilities.map((item, index) => (
+                  <Tag key={`${item.type}-${item.identifier ?? index}`} color="gold" style={{ padding: '4px 12px' }}>
+                    {item.name}
+                  </Tag>
+                ))}
+              </Space>
+            ) : (
+              <Typography.Text type="secondary">
+                儲存後可於團隊詳情頁檢視「資源群組」與「通知策略」等責任關聯。
+              </Typography.Text>
+            )}
+          </Space>
+        </div>
+      </Space>
+    </GlassModal>
   );
 };
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,8 +23,8 @@ const mockApi = {
     db.users[0].preferences = { ...db.users[0].preferences, ...prefs };
     return Promise.resolve(db.users[0].preferences);
   },
-  inviteUser: (email: string) => {
-    console.log(`Mock inviting user: ${email}`);
+  inviteUser: (payload: { email: string; first_name: string; last_name: string; note?: string }) => {
+    console.log('Mock inviting user with payload:', payload);
     return Promise.resolve({ success: true });
   },
   updateUser: (userId: string, data: any) => {
@@ -37,7 +37,8 @@ const mockApi = {
   },
   createTeam: (data: any) => {
     console.log('Mock creating team with data:', data);
-    const newTeam = { id: `team_${Date.now()}`, ...data, member_count: 0 };
+    const memberCount = Array.isArray(data?.member_ids) ? data.member_ids.length : 0;
+    const newTeam = { id: `team_${Date.now()}`, ...data, member_count: memberCount };
     // @ts-ignore
     db.teams.push(newTeam);
     return Promise.resolve(newTeam);
@@ -91,10 +92,10 @@ const realApi = {
     },
     body: JSON.stringify(prefs),
   }).then(res => res.json()),
-  inviteUser: (email: string) => fetch('/api/v1/users/invite', {
+  inviteUser: (payload: { email: string; first_name: string; last_name: string; note?: string }) => fetch('/api/v1/users/invite', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email }),
+    body: JSON.stringify(payload),
   }).then(res => res.json()),
   updateUser: (userId: string, data: any) => fetch(`/api/v1/users/${userId}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- standardize the GlassModal defaults to enforce platform modal styling
- rework identity management modals (invite user, edit user, team form, role form) to follow the documented UX, including new previews and metadata
- add permission tree search support and adjust API stubs for richer invite/team payloads

## Testing
- npm run lint *(fails: existing lint violations across the frontend codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cec5a7f004832d9a52ffba78719dea