### PR TITLE
Align event status enums with silenced state

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -303,7 +303,7 @@ CREATE TABLE `events` (
     `summary` VARCHAR(500) NOT NULL COMMENT '事件摘要',
     `description` TEXT COMMENT '事件描述',
     `severity` ENUM('critical', 'warning', 'info') DEFAULT 'warning' COMMENT '嚴重性',
-    `status` ENUM('firing', 'resolved', 'acknowledged', 'merged') DEFAULT 'firing' COMMENT '狀態',
+    `status` ENUM('new', 'acknowledged', 'resolved', 'silenced') DEFAULT 'new' COMMENT '狀態 (Grafana firing 對應 new)',
     `source` VARCHAR(100) COMMENT '事件來源 (e.g. Prometheus)',
     `resource_id` VARCHAR(36) COMMENT '相關資源ID',
     `rule_id` VARCHAR(255) COMMENT '觸發規則的UID (來自Grafana)',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -474,10 +474,10 @@ paths:
         - $ref: "#/components/parameters/PageSizeParam"
         - name: status
           in: query
-          description: 事件狀態篩選
+          description: 事件狀態篩選。Grafana Alertmanager 原始狀態 `firing` 會在此映射為 `new`，以保持與前端 UI 與資料庫欄位的一致性。
           schema:
             type: string
-            enum: [FIRING, RESOLVED, PENDING]
+            enum: [new, acknowledged, resolved, silenced]
         - name: severity
           in: query
           description: 嚴重度篩選
@@ -1335,7 +1335,11 @@ components:
         id: { type: string, example: "evt_2a7d3e9f" }
         summary: { type: string, example: "CPU high on db-mysql-prod-02" }
         severity: { type: string, enum: [CRITICAL, WARNING, INFO] }
-        status: { type: string, enum: [FIRING, ACKNOWLEDGED, RESOLVED, MERGED] }
+        status:
+          type: string
+          description: "事件狀態。Grafana Alertmanager 的 `firing` 狀態會轉換為 `new`，確保與 UI 與資料庫一致。"
+          enum: [new, acknowledged, resolved, silenced]
+          x-enum-varnames: [NEW, ACKNOWLEDGED, RESOLVED, SILENCED]
         source: { type: string, example: "Prometheus" }
         triggered_at: { type: string, format: "date-time" }
         acknowledged_at: { type: string, format: "date-time", nullable: true }


### PR DESCRIPTION
## Summary
- switch the /events status query parameter to lowercase values (new/acknowledged/resolved/silenced) and document the firing→new mapping
- update the Event schema status enum to the same lowercase set with an explicit description and enum varnames
- align the database events.status enum with the new values and note the firing alias in the column comment

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cf9066cbc8832d8d4f81320e443264