### PR TITLE
Align platform UI demo styling with prototype

### DIFF
--- a/platform-ui-demo.html
+++ b/platform-ui-demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-TW">
+<html lang="zh-Hant">
 
 <head>
   <meta charset="UTF-8" />
@@ -7,7 +7,6 @@
   <title>SRE 平台 UI 元件與圖表規範 Demo</title>
   <link rel="stylesheet" href="https://unpkg.com/antd@5.19.1/dist/reset.css" />
   <style>
-    /* 🎨 統一設計系統 - Design System */
     :root {
       /* === 核心品牌色系統 === */
       --brand-primary: #1890ff;
@@ -75,6 +74,14 @@
       --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.35);
       --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.45);
 
+      /* === 按鈕系統 === */
+      --btn-height-sm: 28px;
+      --btn-height-md: 36px;
+      --btn-height-lg: 44px;
+      --btn-padding-sm: 0 8px;
+      --btn-padding-md: 0 16px;
+      --btn-padding-lg: 0 24px;
+
       /* === 玻璃效果系統 === */
       --glass-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.04) 100%);
       --glass-border: 1px solid rgba(255, 255, 255, 0.12);
@@ -82,150 +89,544 @@
       --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.1);
     }
 
-    /* 頁面樣式 */
+    html,
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       margin: 0;
-      padding: var(--spacing-xl);
+      padding: 0;
       background: var(--bg-page);
       color: var(--text-primary);
-      transition: background 0.3s, color 0.3s;
-      min-height: 100vh;
+      font-family: 'Inter', 'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
+      min-height: 100%;
+      line-height: 1.6;
     }
 
-    h1 {
-      color: var(--brand-primary);
+    body {
+      padding: var(--spacing-3xl);
+      box-sizing: border-box;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: var(--spacing-xl);
+      }
+    }
+
+    .page-shell {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-2xl);
+    }
+
+    .page-header {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-sm);
+    }
+
+    .page-title {
       font-size: 32px;
       font-weight: 600;
-      margin-bottom: var(--spacing-lg);
+      margin: 0;
       background: linear-gradient(135deg, var(--text-primary) 0%, var(--text-secondary) 100%);
       -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
       background-clip: text;
+      -webkit-text-fill-color: transparent;
+      letter-spacing: -0.5px;
     }
 
-    h2 {
-      border-left: 5px solid var(--brand-primary);
-      padding-left: var(--spacing-md);
-      margin-top: var(--spacing-3xl);
-      margin-bottom: var(--spacing-lg);
-      font-size: 24px;
+    .page-subtitle {
+      font-size: 14px;
+      color: var(--text-tertiary);
+      margin: 0;
+      max-width: 760px;
+    }
+
+    .demo-card {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-xl);
+      padding: var(--spacing-2xl);
+      border-radius: var(--radius-lg);
+    }
+
+    .demo-card__header {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: var(--spacing-lg);
+      align-items: flex-start;
+    }
+
+    .section-title {
+      margin: 0;
+      font-size: 20px;
       font-weight: 600;
       color: var(--text-primary);
     }
 
-    .demo-block {
-      background: var(--bg-container);
-      border-radius: var(--radius-lg);
-      padding: var(--spacing-xl);
-      margin-bottom: var(--spacing-xl);
-      box-shadow: var(--shadow-md);
-      transition: all 0.3s ease;
-      border: var(--glass-border);
+    .section-description {
+      margin: 0;
+      font-size: 14px;
+      color: var(--text-tertiary);
+      max-width: 720px;
     }
 
-    .demo-container {
-      margin-top: var(--spacing-md);
-      padding: var(--spacing-lg);
-      border: 1px dashed var(--border-base);
-      border-radius: var(--radius-md);
-      background: var(--bg-elevated);
-      transition: all 0.3s ease;
+    .demo-card__content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-lg);
     }
 
-    .chart-container {
-      width: 100%;
-      height: 300px;
+    .glass-card {
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0%, rgba(200, 200, 200, 0.04) 100%) !important;
+      border: 1px solid rgba(255, 255, 255, 0.12) !important;
+      border-radius: 12px !important;
+      backdrop-filter: blur(20px) saturate(180%) !important;
+      -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
     }
 
-    /* 暗色主題優化 */
-    body.dark-theme {
-      background: #000;
-      color: var(--text-primary);
+    .glass-card-subtle {
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, rgba(200, 200, 200, 0.02) 100%) !important;
+      border: 1px solid rgba(255, 255, 255, 0.08) !important;
+      border-radius: 12px !important;
+      backdrop-filter: blur(20px) saturate(180%) !important;
+      -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.08) !important;
     }
 
-    body.dark-theme h1 {
-      color: var(--brand-primary);
+    .tag-stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: var(--spacing-xl);
     }
 
-    body.dark-theme .demo-block {
-      background: var(--bg-elevated);
-      border-color: var(--border-light);
-    }
-
-    body.dark-theme .demo-container {
-      background: var(--bg-overlay);
-      border-color: var(--border-light);
-    }
-
-    /* ToolbarActions 樣式 */
-    .toolbar-actions {
-      padding: var(--spacing-lg);
+    .tag-stat-card {
       background: var(--glass-bg);
       border: var(--glass-border);
       border-radius: var(--radius-lg);
-      margin-bottom: var(--spacing-lg);
+      padding: var(--spacing-lg);
       backdrop-filter: var(--glass-backdrop);
+      -webkit-backdrop-filter: var(--glass-backdrop);
       box-shadow: var(--glass-shadow);
+      transition: all 0.3s ease;
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-sm);
+    }
+
+    .tag-stat-card:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-lg);
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    .tag-stat-icon {
+      font-size: 18px;
+      color: var(--brand-primary);
+      opacity: 0.75;
+    }
+
+    .tag-stat-value {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--text-primary);
+      line-height: 1;
+    }
+
+    .tag-stat-label {
+      font-size: 12px;
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      font-weight: 600;
+    }
+
+    .form-layout {
+      display: grid;
+      gap: var(--spacing-2xl);
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      align-items: flex-start;
+    }
+
+    .tag-collection {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--spacing-xs);
+    }
+
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: var(--spacing-xl);
+    }
+
+    .chart-panel {
+      height: 260px;
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .search-input {
+      width: 100%;
+    }
+
+    @media (min-width: 992px) {
+      .search-input {
+        width: 320px;
+      }
+    }
+
+    /* === 全域操作按鈕標準化 === */
+    .platform-btn {
+      --btn-height: 36px;
+      --btn-padding: 0 var(--spacing-lg);
+      --btn-font-size: 14px;
+      --btn-font-weight: 500;
+      --btn-border-radius: var(--radius-sm);
+      --btn-transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
+      height: var(--btn-height);
+      padding: var(--btn-padding);
+      font-size: var(--btn-font-size);
+      font-weight: var(--btn-font-weight);
+      border-radius: var(--btn-border-radius);
+      transition: var(--btn-transition);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--spacing-xs);
+      white-space: nowrap;
+      cursor: pointer;
+      border: 1px solid transparent;
+      background: transparent;
+      color: var(--text-secondary);
+    }
+
+    .platform-btn:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+
+    .platform-btn--primary {
+      background: var(--brand-primary);
+      border-color: var(--brand-primary);
+      color: white;
+    }
+
+    .platform-btn--primary:hover:not(:disabled) {
+      background: var(--brand-primary-hover);
+      border-color: var(--brand-primary-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(24, 144, 255, 0.3);
+    }
+
+    .platform-btn--secondary {
+      border-color: var(--border-base);
+      color: var(--text-secondary);
+      background: var(--bg-elevated);
+    }
+
+    .platform-btn--secondary:hover:not(:disabled) {
+      border-color: var(--border-hover);
+      background: var(--bg-hover);
+      color: var(--text-primary);
+      transform: translateY(-1px);
+    }
+
+    .platform-btn--danger {
+      background: var(--brand-danger);
+      border-color: var(--brand-danger);
+      color: white;
+    }
+
+    .platform-btn--danger:hover:not(:disabled) {
+      background: var(--brand-danger-hover);
+      border-color: var(--brand-danger-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(255, 77, 79, 0.3);
+    }
+
+    .platform-btn--ghost {
+      --btn-bg: transparent;
+      --btn-color: var(--text-tertiary);
+      --btn-border-color: var(--border-light);
+      --btn-bg-hover: var(--bg-hover);
+      --btn-color-hover: var(--text-secondary);
+      --btn-border-color-hover: var(--border-base);
+      background: var(--btn-bg);
+      color: var(--btn-color);
+      border-color: var(--btn-border-color);
+    }
+
+    .platform-btn--ghost:hover:not(:disabled) {
+      background: var(--btn-bg-hover);
+      color: var(--btn-color-hover);
+      border-color: var(--btn-border-color-hover);
+    }
+
+    .platform-btn--text {
+      --btn-bg: transparent;
+      --btn-color: var(--text-tertiary);
+      --btn-border-color: transparent;
+      --btn-bg-hover: var(--bg-hover);
+      --btn-color-hover: var(--text-secondary);
+      padding: var(--spacing-xs) var(--spacing-sm);
+      background: var(--btn-bg);
+      color: var(--btn-color);
+      border-color: var(--btn-border-color);
+    }
+
+    .platform-btn--text:hover:not(:disabled) {
+      background: var(--btn-bg-hover);
+      color: var(--btn-color-hover);
+    }
+
+    .platform-btn--small {
+      --btn-height: 28px;
+      --btn-padding: 0 var(--spacing-md);
+      --btn-font-size: 12px;
+    }
+
+    .platform-btn--large {
+      --btn-height: 44px;
+      --btn-padding: 0 var(--spacing-2xl);
+      --btn-font-size: 16px;
+    }
+
+    .platform-btn--icon-only {
+      --btn-padding: 0;
+      width: var(--btn-height);
+      min-width: var(--btn-height);
+    }
+
+    .table-row-actions {
+      display: flex;
+      gap: var(--spacing-xs);
+      align-items: center;
+      justify-content: center;
+      min-width: 96px;
+    }
+
+    .table-row-actions .platform-btn {
+      opacity: 0.75;
+      transition: all 0.2s ease;
+    }
+
+    .table-row-actions .platform-btn:hover {
+      opacity: 1;
+      transform: scale(1.05);
+    }
+
+    .table-action-delete:hover {
+      --btn-color-hover: var(--brand-danger);
+      --btn-bg-hover: rgba(255, 77, 79, 0.12);
+    }
+
+    .toolbar-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      gap: var(--spacing-lg);
+      padding: var(--spacing-md) 0;
     }
 
     .toolbar-group {
       display: flex;
-      align-items: center;
       gap: var(--spacing-sm);
+      align-items: center;
     }
 
-    .toolbar-group--primary {
-      flex: 1;
+    .toolbar-group--secondary .platform-btn {
+      opacity: 0.8;
     }
 
-    .toolbar-group--secondary {
-      flex-shrink: 0;
+    .toolbar-group--secondary .platform-btn:hover {
+      opacity: 1;
     }
 
-    body.dark-theme .toolbar-actions {
+    .filter-active {
+      --btn-color: var(--brand-primary);
+      --btn-bg: rgba(24, 144, 255, 0.12);
+      --btn-border-color: var(--brand-primary);
+    }
+
+    .table-wrapper {
       background: var(--glass-bg);
-      border-color: var(--border-base);
+      border: var(--glass-border);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--glass-shadow);
+      backdrop-filter: var(--glass-backdrop);
+      -webkit-backdrop-filter: var(--glass-backdrop);
     }
 
-    /* === 🔧 Ant Design 元件樣式優化 === */
+    .table-toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--spacing-lg);
+      padding: var(--spacing-lg);
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border-light);
+      min-height: 64px;
+    }
 
-    /* 統一按鈕樣式 */
-    .ant-btn {
+    .table-wrapper .ant-table {
+      background: transparent;
+    }
+
+    .table-wrapper .ant-table-thead>tr>th {
+      background: var(--bg-elevated);
+      color: var(--text-primary);
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      padding: var(--spacing-lg) var(--spacing-lg);
+      height: 48px;
+      line-height: 1.2;
+      border-bottom: 2px solid var(--border-base);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .table-wrapper .ant-table-thead>tr>th .ant-table-column-sorter {
+      opacity: 0.6;
+      transition: opacity 0.2s ease;
+    }
+
+    .table-wrapper .ant-table-thead>tr>th:hover .ant-table-column-sorter {
+      opacity: 1;
+    }
+
+    .table-wrapper .ant-table-tbody>tr {
+      transition: all 0.2s ease;
+      height: 52px;
+    }
+
+    .table-wrapper .ant-table-tbody>tr:hover {
+      background: var(--bg-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    .table-wrapper .ant-table-tbody>tr>td {
+      color: var(--text-secondary);
+      padding: var(--spacing-md) var(--spacing-lg);
+      line-height: 1.4;
+      border-bottom: 1px solid var(--border-light);
+      vertical-align: middle;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 220px;
+    }
+
+    .table-wrapper .ant-table-row-selected>td {
+      background: var(--bg-selected) !important;
+      border-left: 3px solid var(--brand-primary);
+    }
+
+    .table-wrapper .ant-pagination {
+      margin: var(--spacing-lg) 0 !important;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    .table-wrapper .ant-table-container::-webkit-scrollbar {
+      height: 8px;
+    }
+
+    .table-wrapper .ant-table-container::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 4px;
+    }
+
+    .table-wrapper .ant-table-container::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+      border-radius: 4px;
+    }
+
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 12px;
+      border-radius: var(--radius-xl);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      transition: all 0.2s ease;
+    }
+
+    .status-badge::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: currentColor;
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+
+      50% {
+        opacity: 0.6;
+        transform: scale(0.8);
+      }
+
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    .status-healthy,
+    .status-badge-healthy {
+      background: rgba(95, 207, 128, 0.12);
+      color: var(--brand-success);
+      border: 1px solid rgba(95, 207, 128, 0.24);
+    }
+
+    .status-warning,
+    .status-badge-warning {
+      background: rgba(255, 184, 77, 0.12);
+      color: var(--brand-warning);
+      border: 1px solid rgba(255, 184, 77, 0.24);
+    }
+
+    .status-critical,
+    .status-badge-critical {
+      background: rgba(255, 99, 99, 0.12);
+      color: var(--brand-danger);
+      border: 1px solid rgba(255, 99, 99, 0.24);
+    }
+
+    .ant-form-item-label>label {
       font-size: 14px;
       font-weight: 500;
-      line-height: 1.5;
-      border-radius: var(--radius-sm);
-      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    }
-
-    .ant-btn-primary {
-      background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-hover) 100%);
-      border: none;
-      box-shadow: 0 2px 8px rgba(24, 144, 255, 0.3);
-    }
-
-    .ant-btn-primary:hover {
-      background: linear-gradient(135deg, var(--brand-primary-hover) 0%, var(--brand-primary) 100%);
-      box-shadow: 0 4px 12px rgba(24, 144, 255, 0.4);
-      transform: translateY(-1px);
-    }
-
-    .ant-btn-default {
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid var(--border-light);
-      color: var(--text-secondary);
-    }
-
-    .ant-btn-default:hover {
-      background: rgba(255, 255, 255, 0.12);
-      border-color: var(--border-hover);
       color: var(--text-primary);
     }
 
-    /* 統一輸入框樣式 */
+    .ant-form-item {
+      margin-bottom: var(--spacing-lg);
+    }
+
     .ant-input,
     .ant-input-password,
+    .ant-input-affix-wrapper,
     .ant-select-selector {
       background: var(--bg-container) !important;
       border: 1px solid var(--border-light) !important;
@@ -240,6 +641,7 @@
     }
 
     .ant-input:hover,
+    .ant-input-affix-wrapper:hover,
     .ant-input-password:hover,
     .ant-select-selector:hover {
       border-color: var(--border-hover) !important;
@@ -247,52 +649,13 @@
 
     .ant-input:focus,
     .ant-input-focused,
+    .ant-input-affix-wrapper-focused,
     .ant-input-password:focus-within,
     .ant-select-focused .ant-select-selector {
       border-color: var(--brand-primary) !important;
       box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.1) !important;
     }
 
-    /* 統一表單標籤樣式 */
-    .ant-form-item-label>label {
-      font-size: 14px;
-      font-weight: 500;
-      color: var(--text-primary);
-    }
-
-    /* 統一表單項間距 */
-    .ant-form-item {
-      margin-bottom: var(--spacing-lg);
-    }
-
-    .ant-form-item:last-child {
-      margin-bottom: 0;
-    }
-
-    /* 統一按鈕間距 */
-    .ant-btn+.ant-btn {
-      margin-left: var(--spacing-sm);
-    }
-
-    .ant-btn-group {
-      margin-right: var(--spacing-md);
-    }
-
-    /* 統一卡片樣式 */
-    .ant-card {
-      background: var(--bg-container);
-      border: var(--glass-border);
-      border-radius: var(--radius-md);
-      box-shadow: var(--shadow-sm);
-    }
-
-    .ant-card-head-title {
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--text-primary);
-    }
-
-    /* 統一模態框樣式 */
     .ant-modal-content {
       background: var(--bg-elevated);
       border: var(--glass-border);
@@ -308,100 +671,29 @@
 
     .ant-modal-body {
       padding: var(--spacing-xl);
+      color: var(--text-secondary);
     }
 
-    /* 統一下拉選單樣式 */
-    .ant-select-dropdown {
+    .ant-modal-footer {
+      border-top: 1px solid var(--border-light);
+      padding: var(--spacing-lg) var(--spacing-xl);
+    }
+
+    .ant-drawer-content {
       background: var(--bg-elevated);
-      border: var(--glass-border);
-      border-radius: var(--radius-md);
-      box-shadow: var(--shadow-lg);
+      border-left: var(--glass-border);
     }
 
-    .ant-select-dropdown .ant-select-item-option {
-      padding: 8px 12px !important;
-      color: var(--text-primary);
+    .ant-drawer-header {
+      border-bottom: 1px solid var(--border-light);
     }
 
-    .ant-select-dropdown .ant-select-item-option:hover {
-      background: rgba(255, 255, 255, 0.05) !important;
+    .ant-drawer-body {
+      color: var(--text-secondary);
     }
 
-    .ant-select-dropdown .ant-select-item-option-selected {
-      background: rgba(24, 144, 255, 0.1) !important;
-      color: var(--brand-primary);
-    }
-
-    /* 統一分頁器樣式 */
-    .ant-pagination {
-      margin-top: var(--spacing-lg);
-      text-align: center;
-    }
-
-    .ant-pagination-item,
-    .ant-pagination-prev,
-    .ant-pagination-next {
-      border: 1px solid var(--border-light) !important;
-      background: var(--bg-container) !important;
-      color: var(--text-secondary) !important;
-      border-radius: var(--radius-sm) !important;
-    }
-
-    .ant-pagination-item:hover,
-    .ant-pagination-prev:hover,
-    .ant-pagination-next:hover {
-      border-color: var(--border-hover) !important;
-      color: var(--text-primary) !important;
-    }
-
-    .ant-pagination-item-active {
-      background: var(--brand-primary) !important;
-      border-color: var(--brand-primary) !important;
-      color: white !important;
-    }
-
-    /* 統一標籤樣式 */
-    .ant-tag {
-      border-radius: var(--radius-sm);
-      font-size: 12px;
-      font-weight: 500;
-    }
-
-    /* 統一徽章樣式 */
-    .ant-badge {
-      font-size: 12px;
-    }
-
-    /* 暗色主題下的 Ant Design 元件優化 */
-    body.dark-theme .ant-btn-default {
-      background: rgba(255, 255, 255, 0.05);
-      border-color: rgba(255, 255, 255, 0.15);
-      color: rgba(255, 255, 255, 0.85);
-    }
-
-    body.dark-theme .ant-btn-default:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: rgba(255, 255, 255, 0.25);
-      color: white;
-    }
-
-    body.dark-theme .ant-input,
-    body.dark-theme .ant-input-password,
-    body.dark-theme .ant-select-selector {
-      background: var(--bg-elevated) !important;
-      border-color: rgba(255, 255, 255, 0.15) !important;
-    }
-
-    body.dark-theme .ant-card {
-      background: var(--bg-elevated);
-      border-color: rgba(255, 255, 255, 0.15);
-    }
-
-    /* === 🔧 其他 Ant Design 元件樣式優化 === */
-
-    /* Tabs 樣式 */
     .ant-tabs {
-      margin-top: var(--spacing-md);
+      margin-top: var(--spacing-sm);
     }
 
     .ant-tabs .ant-tabs-content-holder {
@@ -432,7 +724,6 @@
       background: var(--brand-primary);
     }
 
-    /* Timeline 樣式 */
     .ant-timeline-item-head {
       background: var(--bg-container);
       border: 2px solid var(--border-light);
@@ -448,27 +739,13 @@
       border-color: var(--brand-danger);
     }
 
-    .ant-timeline-item-head-orange {
-      background: var(--brand-warning);
-      border-color: var(--brand-warning);
-    }
-
     .ant-timeline-item-head-green {
       background: var(--brand-success);
       border-color: var(--brand-success);
     }
 
-    .ant-timeline-item-content {
-      margin-left: var(--spacing-md);
-    }
-
-    /* Descriptions 樣式 */
     .ant-descriptions {
       margin-bottom: var(--spacing-lg);
-    }
-
-    .ant-descriptions-item {
-      padding: var(--spacing-sm) 0;
     }
 
     .ant-descriptions-item-label {
@@ -492,7 +769,6 @@
       border-bottom: 1px solid var(--border-light);
     }
 
-    /* Tag 樣式 */
     .ant-tag {
       margin: 2px 4px 2px 0;
       padding: 2px 8px;
@@ -526,194 +802,33 @@
       border-color: rgba(255, 77, 79, 0.2);
     }
 
-    .ant-tag-purple {
-      background: rgba(114, 46, 209, 0.1);
-      color: var(--brand-info);
-      border-color: rgba(114, 46, 209, 0.2);
+    .ant-pagination-item,
+    .ant-pagination-prev,
+    .ant-pagination-next {
+      border: 1px solid var(--border-light) !important;
+      background: var(--bg-container) !important;
+      color: var(--text-secondary) !important;
+      border-radius: var(--radius-sm) !important;
     }
 
-    /* 表格樣式 */
-    .ant-table-wrapper {
-      margin-top: var(--spacing-lg);
+    .ant-pagination-item:hover,
+    .ant-pagination-prev:hover,
+    .ant-pagination-next:hover {
+      border-color: var(--border-hover) !important;
+      color: var(--text-primary) !important;
     }
 
-    .ant-table {
-      background: transparent;
-    }
-
-    .ant-table-thead>tr>th {
-      background: var(--bg-elevated);
-      color: var(--text-primary);
-      font-weight: 600;
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 0.8px;
-      padding: var(--spacing-lg);
-      height: 48px;
-      line-height: 1.2;
-      border-bottom: 2px solid var(--border-base);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .ant-table-tbody>tr {
-      transition: all 0.2s ease;
-    }
-
-    .ant-table-tbody>tr:hover>td {
-      background: var(--bg-hover);
-    }
-
-    .ant-table-tbody>tr>td {
-      padding: var(--spacing-lg);
-      border-bottom: 1px solid var(--border-light);
-      color: var(--text-secondary);
-    }
-
-    .ant-table-column-sorter {
-      opacity: 0.6;
-      transition: opacity 0.2s ease;
-    }
-
-    .ant-table-thead>tr>th:hover .ant-table-column-sorter {
-      opacity: 1;
-    }
-
-    /* 表單樣式 */
-    .ant-form {
-      margin-bottom: var(--spacing-lg);
-    }
-
-    .ant-form-item {
-      margin-bottom: var(--spacing-lg);
-    }
-
-    .ant-form-item:last-child {
-      margin-bottom: 0;
-    }
-
-    /* 間距統一 */
-    .ant-btn+.ant-btn {
-      margin-left: var(--spacing-sm);
-    }
-
-    .ant-btn-group {
-      margin-right: var(--spacing-md);
-    }
-
-    /* 暗色主題下的其他元件優化 */
-    body.dark-theme .ant-tabs-tab {
-      color: var(--text-secondary);
-    }
-
-    body.dark-theme .ant-tabs-tab.ant-tabs-tab-active {
-      background: var(--brand-primary);
-      color: white;
-    }
-
-    body.dark-theme .ant-tabs-tab:hover {
-      background: rgba(24, 144, 255, 0.1);
-      color: var(--text-primary);
-    }
-
-    body.dark-theme .ant-timeline-item-head {
-      background: var(--bg-elevated);
-      border-color: var(--border-light);
-    }
-
-    body.dark-theme .ant-descriptions-bordered .ant-descriptions-item-label,
-    body.dark-theme .ant-descriptions-bordered .ant-descriptions-item-content {
-      border-bottom-color: var(--border-light);
-    }
-
-    body.dark-theme .ant-table-thead>tr>th {
-      background: var(--bg-overlay);
-      border-bottom-color: var(--border-light);
-    }
-
-    body.dark-theme .ant-table-tbody>tr>td {
-      border-bottom-color: var(--border-light);
+    .ant-pagination-item-active {
+      background: var(--brand-primary) !important;
+      border-color: var(--brand-primary) !important;
+      color: white !important;
     }
   </style>
 </head>
 
 <body>
-  <h1>SRE 平台 UI 元件與圖表規範 Demo v4</h1>
+  <div id="root"></div>
 
-  <div class="demo-block">
-    <h2>🎨 主題切換</h2>
-    <div id="demo-theme" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>按鈕 (Button)</h2>
-    <div id="demo-button" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>表單 (Form)</h2>
-    <div id="demo-form" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>表格 (Table)</h2>
-    <div id="demo-table" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Modal / Drawer</h2>
-    <div id="demo-modal" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>訊息提示 (Message / Notification)</h2>
-    <div id="demo-message" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Tabs</h2>
-    <div id="demo-tabs" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Timeline</h2>
-    <div id="demo-timeline" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Card</h2>
-    <div id="demo-card" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Descriptions</h2>
-    <div id="demo-descriptions" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>Tag</h2>
-    <div id="demo-tag" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>ToolbarActions (平台標準工具列)</h2>
-    <div id="demo-toolbar" class="demo-container"></div>
-  </div>
-
-  <div class="demo-block">
-    <h2>ECharts 圖表</h2>
-    <h3>Bar Chart</h3>
-    <div id="demo-bar" class="chart-container"></div>
-    <h3>Pie Chart</h3>
-    <div id="demo-pie" class="chart-container"></div>
-    <h3>Line Chart</h3>
-    <div id="demo-line" class="chart-container"></div>
-    <h3>Heatmap</h3>
-    <div id="demo-heatmap" class="chart-container"></div>
-  </div>
-
-  <!-- React, Babel, Dayjs, AntD, ECharts -->
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -723,488 +838,737 @@
   <script src="https://unpkg.com/echarts/dist/echarts.min.js"></script>
 
   <script type="text/babel">
-    const { Button, Form, Input, Table, Modal, Drawer, notification, message, Tabs, Timeline, Card, Descriptions, Tag, Switch, Space, Tooltip, Popover, Badge } = window.antd;
+    const {
+      Form,
+      Input,
+      Table,
+      Modal,
+      Drawer,
+      Tabs,
+      Timeline,
+      Descriptions,
+      Tag,
+      Space,
+      Tooltip,
+      Badge,
+      message,
+      Spin
+    } = window.antd;
 
-    // Theme Toggle
-    const ThemeToggle = () => {
-      const [dark, setDark] = React.useState(false);
-      React.useEffect(() => {
-        document.body.className = dark ? "dark-theme" : "";
-      }, [dark]);
-      return <Switch checkedChildren="🌙 Dark" unCheckedChildren="☀️ Light" checked={dark} onChange={setDark} />;
-    };
-    const root1 = ReactDOM.createRoot(document.getElementById('demo-theme'));
-    root1.render(<ThemeToggle />);
+    const {
+      EyeOutlined,
+      EditOutlined,
+      DeleteOutlined,
+      ReloadOutlined,
+      FilterOutlined,
+      DownloadOutlined,
+      PlusOutlined,
+      SearchOutlined
+    } = window.icons;
 
-    // Button Demo
-    const ButtonDemo = () => (
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <Button type="primary">主要按鈕</Button>
-        <Button>次要按鈕</Button>
-        <Button type="dashed">虛線按鈕</Button>
-        <Button type="text">文字按鈕</Button>
-        <Button danger>刪除按鈕</Button>
-      </div>
-    );
-    const root2 = ReactDOM.createRoot(document.getElementById('demo-button'));
-    root2.render(<ButtonDemo />);
-
-    // Form Demo
-    const FormDemo = () => {
-      const [form] = Form.useForm();
-      const onFinish = values => message.success(JSON.stringify(values));
-      return (
-        <Form form={form} layout="vertical" onFinish={onFinish} style={{ maxWidth: 400 }}>
-          <Form.Item label="用戶名稱" name="username" rules={[{ required: true }]}>
-            <Input placeholder="請輸入用戶名稱" />
-          </Form.Item>
-          <Form.Item label="密碼" name="password" rules={[{ required: true }]}>
-            <Input.Password placeholder="請輸入密碼" />
-          </Form.Item>
-          <Button type="primary" htmlType="submit">提交</Button>
-        </Form>
-      );
-    };
-    const root3 = ReactDOM.createRoot(document.getElementById('demo-form'));
-    root3.render(<FormDemo />);
-
-    // Table Demo
-    const columns = [
-      { title: '名稱', dataIndex: 'name', key: 'name' },
-      { title: '狀態', dataIndex: 'status', key: 'status' },
-      { title: '更新時間', dataIndex: 'time', key: 'time' },
-    ];
-    const data = [
-      { key: 1, name: '服務 A', status: '健康', time: '10:30' },
-      { key: 2, name: '服務 B', status: '警告', time: '10:35' },
-      { key: 3, name: '服務 C', status: '嚴重', time: '10:40' },
-    ];
-    const root4 = ReactDOM.createRoot(document.getElementById('demo-table'));
-    root4.render(<Table columns={columns} dataSource={data} pagination={false} />);
-
-    // Modal / Drawer Demo
-    const ModalDemo = () => {
-      const [open, setOpen] = React.useState(false);
-      const [drawer, setDrawer] = React.useState(false);
-      return (
-        <div style={{ display: 'flex', gap: 8 }}>
-          <Button type="primary" onClick={() => setOpen(true)}>開啟 Modal</Button>
-          <Modal open={open} onCancel={() => setOpen(false)} onOk={() => setOpen(false)}>這是一個示範用的 Modal</Modal>
-          <Button type="dashed" onClick={() => setDrawer(true)}>開啟 Drawer</Button>
-          <Drawer open={drawer} onClose={() => setDrawer(false)} title="抽屜面板">這是一個示範用的 Drawer</Drawer>
-        </div>
-      );
-    };
-    const root5 = ReactDOM.createRoot(document.getElementById('demo-modal'));
-    root5.render(<ModalDemo />);
-
-    // Message / Notification Demo
-    const MessageDemo = () => (
-      <div style={{ display: 'flex', gap: 8 }}>
-        <Button onClick={() => message.success('操作成功')}>成功訊息</Button>
-        <Button onClick={() => message.error('操作失敗')}>錯誤訊息</Button>
-        <Button onClick={() => notification.info({ message: '通知標題', description: '這是一則通知' })}>通知</Button>
-      </div>
-    );
-    const root6 = ReactDOM.createRoot(document.getElementById('demo-message'));
-    root6.render(<MessageDemo />);
-
-    // Tabs Demo
-    const TabsDemo = () => (
-      <Tabs
-        defaultActiveKey="1"
-        items={[
-          { key: '1', label: '事件管理', children: <p>事件內容</p> },
-          { key: '2', label: '資源列表', children: <p>資源內容</p> },
-          { key: '3', label: '自動化', children: <p>自動化內容</p> },
-        ]}
-      />
-    );
-    const root7 = ReactDOM.createRoot(document.getElementById('demo-tabs'));
-    root7.render(<TabsDemo />);
-
-    // Timeline Demo
-    const TimelineDemo = () => (
-      <Timeline
-        items={[
-          { children: '10:00 啟動系統' },
-          { children: '10:30 偵測到異常', color: 'red' },
-          { children: '10:45 觸發告警', color: 'orange' },
-          { children: '11:00 問題解決', color: 'green' },
-        ]}
-      />
-    );
-    const root8 = ReactDOM.createRoot(document.getElementById('demo-timeline'));
-    root8.render(<TimelineDemo />);
-
-    // Card Demo
-    const CardDemo = () => (
-      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-        <Card title="今日營收" style={{ width: 200 }}>
-          <p style={{ fontSize: 20, color: '#52c41a' }}>¥ 485,720</p>
-          <p>趨勢: +12%</p>
-        </Card>
-        <Card title="活躍用戶" style={{ width: 200 }}>
-          <p style={{ fontSize: 20, color: '#1677ff' }}>8,934</p>
-          <p>趨勢: +8%</p>
-        </Card>
-        <Card title="系統可用性" style={{ width: 200 }}>
-          <p style={{ fontSize: 20, color: '#faad14' }}>99.8%</p>
-          <p>趨勢: -0.2%</p>
-        </Card>
-      </div>
-    );
-    const root9 = ReactDOM.createRoot(document.getElementById('demo-card'));
-    root9.render(<CardDemo />);
-
-    // Descriptions Demo
-    const DescriptionsDemo = () => (
-      <Descriptions title="服務 A 詳細資訊" bordered>
-        <Descriptions.Item label="服務名稱">服務 A</Descriptions.Item>
-        <Descriptions.Item label="狀態"><Tag color="green">健康</Tag></Descriptions.Item>
-        <Descriptions.Item label="最後更新時間">2025-09-21 10:30</Descriptions.Item>
-      </Descriptions>
-    );
-    const root10 = ReactDOM.createRoot(document.getElementById('demo-descriptions'));
-    root10.render(<DescriptionsDemo />);
-
-    // Tag Demo
-    const TagDemo = () => (
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <Tag color="blue">Web</Tag>
-        <Tag color="geekblue">DB</Tag>
-        <Tag color="purple">Cache</Tag>
-        <Tag color="green">健康</Tag>
-        <Tag color="orange">警告</Tag>
-        <Tag color="red">嚴重</Tag>
-      </div>
-    );
-    const root11 = ReactDOM.createRoot(document.getElementById('demo-tag'));
-    root11.render(<TagDemo />);
-
-    // ToolbarActions Demo (平台標準工具列)
-    const ToolbarActions = React.memo(({
-      onRefresh,
-      onSearch,
-      onExport,
-      onAdd,
-      onFilter,
-      onBatchAction,
-      filterActive = false,
-      searchPlaceholder = "搜尋...",
-      showRefresh = true,
-      showSearch = true,
-      showExport = true,
-      showAdd = true,
-      showBatchAction = true,
-      showFilter = true,
-      customActions = []
+    const PlatformButton = React.memo(({
+      variant = 'secondary',
+      size = 'medium',
+      icon,
+      loading = false,
+      disabled = false,
+      children,
+      className = '',
+      htmlType = 'button',
+      tooltip,
+      ...props
     }) => {
-      const [searchValue, setSearchValue] = React.useState('');
-      const icons = window['@ant-design/icons'] || {};
-      const {
-        ReloadOutlined,
-        SearchOutlined,
-        CloseOutlined,
-        FilterOutlined,
-        DownloadOutlined,
-        ControlOutlined,
-        PlusOutlined,
-        SettingOutlined,
-        InfoCircleOutlined,
-        BarChartOutlined
-      } = icons;
+      const classNames = [
+        'platform-btn',
+        `platform-btn--${variant}`,
+        size !== 'medium' ? `platform-btn--${size}` : '',
+        icon && !children ? 'platform-btn--icon-only' : '',
+        className
+      ].filter(Boolean).join(' ');
 
-      return (
-        <Space size="middle" className="toolbar-actions" style={{ width: '100%', justifyContent: 'space-between', flexWrap: 'wrap' }}>
-          <Space size="small" className="toolbar-group toolbar-group--primary">
-            {showRefresh && onRefresh && ReloadOutlined && (
-              <Tooltip title="重新載入">
-                <Button
-                  type="text"
-                  icon={React.createElement(ReloadOutlined)}
-                  onClick={onRefresh}
-                  style={{ borderRadius: '6px' }}
-                />
-              </Tooltip>
-            )}
-            {showSearch && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                <Input
-                  placeholder={searchPlaceholder}
-                  value={searchValue}
-                  onChange={(e) => setSearchValue(e.target.value)}
-                  onPressEnter={() => onSearch && onSearch(searchValue)}
-                  style={{ width: '200px', borderRadius: '6px' }}
-                  prefix={SearchOutlined && React.createElement(SearchOutlined)}
-                  suffix={
-                    searchValue && (
-                      <Button
-                        type="text"
-                        size="small"
-                        icon={CloseOutlined && React.createElement(CloseOutlined)}
-                        onClick={() => setSearchValue('')}
-                        style={{ padding: '2px' }}
-                      />
-                    )
-                  }
-                />
-                {onSearch && (
-                  <Tooltip title="搜尋">
-                    <Button
-                      type="primary"
-                      icon={SearchOutlined && React.createElement(SearchOutlined)}
-                      onClick={() => onSearch(searchValue)}
-                      style={{ borderRadius: '6px' }}
-                    >
-                      搜尋
-                    </Button>
-                  </Tooltip>
-                )}
-                {showFilter && onFilter && (
-                  <Popover
-                    content={
-                      <div style={{ width: '200px', padding: '8px' }}>
-                        <div style={{ marginBottom: '12px', fontWeight: 600, color: 'rgba(0, 0, 0, 0.9)' }}>
-                          篩選條件
-                        </div>
-                        <Button
-                          type="primary"
-                          size="small"
-                          onClick={onFilter}
-                          style={{ width: '100%' }}
-                        >
-                          開啟篩選器
-                        </Button>
-                      </div>
-                    }
-                    trigger="hover"
-                    placement="bottom"
-                  >
-                    <Tooltip title="篩選">
-                      <Button
-                        type="text"
-                        icon={FilterOutlined && React.createElement(FilterOutlined)}
-                        style={{
-                          borderRadius: '6px',
-                          color: filterActive ? '#1890ff' : undefined
-                        }}
-                      />
-                    </Tooltip>
-                  </Popover>
-                )}
-              </div>
-            )}
-          </Space>
-
-          <Space size="small" className="toolbar-group toolbar-group--secondary">
-            {customActions.length > 0 && (
-              <Space size="small">
-                {customActions.map((action, index) => (
-                  <Tooltip title={action.tooltip} key={index}>
-                    <Button
-                      type={action.type || "text"}
-                      icon={action.icon}
-                      onClick={action.onClick}
-                      style={{ borderRadius: '6px' }}
-                    >
-                      {action.label}
-                    </Button>
-                  </Tooltip>
-                ))}
-              </Space>
-            )}
-            {showExport && onExport && (
-              <Tooltip title="匯出資料">
-                <Button
-                  type="text"
-                  icon={DownloadOutlined && React.createElement(DownloadOutlined)}
-                  onClick={onExport}
-                  style={{ borderRadius: '6px' }}
-                />
-              </Tooltip>
-            )}
-            {showBatchAction && onBatchAction && (
-              <Tooltip title="批次操作">
-                <Button
-                  type="text"
-                  icon={ControlOutlined && React.createElement(ControlOutlined)}
-                  onClick={onBatchAction}
-                  style={{ borderRadius: '6px' }}
-                />
-              </Tooltip>
-            )}
-            {showAdd && onAdd && (
-              <Button
-                type="primary"
-                icon={PlusOutlined && React.createElement(PlusOutlined)}
-                onClick={onAdd}
-                style={{ borderRadius: '6px' }}
-              >
-                新增
-              </Button>
-            )}
-          </Space>
-        </Space>
+      const ButtonContent = (
+        <button
+          className={classNames}
+          disabled={disabled || loading}
+          type={htmlType}
+          {...props}
+        >
+          {loading ? <Spin size="small" /> : icon}
+          {children}
+        </button>
       );
+
+      return tooltip ? (
+        <Tooltip title={tooltip}>
+          {ButtonContent}
+        </Tooltip>
+      ) : ButtonContent;
     });
 
-    const ToolbarDemo = () => {
-      const icons = window['@ant-design/icons'] || {};
-      const {
-        SettingOutlined,
-        InfoCircleOutlined,
-        BarChartOutlined
-      } = icons;
-      const [filterActive, setFilterActive] = React.useState(false);
+    const TableRowActions = React.memo(({ record, onEdit, onDelete, onView, customActions = [] }) => (
+      <Space size="small" className="table-row-actions">
+        {onView && (
+          <PlatformButton
+            variant="text"
+            size="small"
+            icon={<EyeOutlined />}
+            tooltip="查看詳情"
+            onClick={() => onView(record)}
+          />
+        )}
+        {onEdit && (
+          <PlatformButton
+            variant="text"
+            size="small"
+            icon={<EditOutlined />}
+            tooltip="編輯設定"
+            onClick={() => onEdit(record)}
+          />
+        )}
+        {onDelete && (
+          <PlatformButton
+            variant="text"
+            size="small"
+            icon={<DeleteOutlined />}
+            tooltip="刪除"
+            className="table-action-delete"
+            onClick={() => onDelete(record)}
+          />
+        )}
+        {customActions.map((action, index) => (
+          <PlatformButton
+            key={index}
+            variant={action.variant || 'text'}
+            size="small"
+            icon={action.icon}
+            tooltip={action.tooltip}
+            onClick={() => action.onClick(record)}
+            {...action.props}
+          />
+        ))}
+      </Space>
+    ));
 
-      const handleRefresh = () => {
-        message.success('資料已重新載入');
+    const ToolbarActions = React.memo(({ onRefresh, onExport, onAdd, onFilter, filterActive = false, customActions = [] }) => (
+      <Space size="middle" className="toolbar-actions">
+        <Space size="small" className="toolbar-group toolbar-group--secondary">
+          {onRefresh && (
+            <PlatformButton
+              variant="ghost"
+              size="small"
+              icon={<ReloadOutlined />}
+              tooltip="重新載入"
+              onClick={onRefresh}
+            />
+          )}
+          {onFilter && (
+            <PlatformButton
+              variant="ghost"
+              size="small"
+              icon={<FilterOutlined />}
+              tooltip="篩選條件"
+              className={filterActive ? 'filter-active' : ''}
+              onClick={onFilter}
+            />
+          )}
+          {onExport && (
+            <PlatformButton
+              variant="ghost"
+              size="small"
+              icon={<DownloadOutlined />}
+              tooltip="匯出資料"
+              onClick={onExport}
+            />
+          )}
+        </Space>
+
+        {customActions.length > 0 && (
+          <Space size="small" className="toolbar-group toolbar-group--custom">
+            {customActions.map((action, index) => (
+              <PlatformButton
+                key={index}
+                variant={action.variant || 'ghost'}
+                size="small"
+                icon={action.icon}
+                tooltip={action.tooltip}
+                onClick={action.onClick}
+                {...action.props}
+              >
+                {action.text}
+              </PlatformButton>
+            ))}
+          </Space>
+        )}
+
+        {onAdd && (
+          <Space size="small" className="toolbar-group toolbar-group--primary">
+            <PlatformButton
+              variant="primary"
+              size="medium"
+              icon={<PlusOutlined />}
+              onClick={onAdd}
+            >
+              新增
+            </PlatformButton>
+          </Space>
+        )}
+      </Space>
+    ));
+
+    const Section = ({ title, description, extra, children }) => (
+      <section className="demo-card glass-card">
+        <div className="demo-card__header">
+          <div>
+            <h2 className="section-title">{title}</h2>
+            {description && <p className="section-description">{description}</p>}
+          </div>
+          {extra && <div className="demo-card__extra">{extra}</div>}
+        </div>
+        <div className="demo-card__content">
+          {children}
+        </div>
+      </section>
+    );
+
+    const StatusBadge = ({ status }) => {
+      const labelMap = {
+        healthy: '健康',
+        warning: '警告',
+        critical: '嚴重'
       };
+      const className = `status-badge status-${status}`;
+      return <span className={className}>{labelMap[status] || status}</span>;
+    };
 
-      const handleSearch = (value) => {
-        message.info(`搜尋: ${value || '全部'}`);
-      };
-
-      const handleExport = () => {
-        message.success('資料已匯出');
-      };
-
-      const handleAdd = () => {
-        message.success('新增項目');
-      };
-
-      const handleFilter = () => {
-        setFilterActive(!filterActive);
-        message.info(filterActive ? '篩選器已關閉' : '篩選器已開啟');
-      };
-
-      const handleBatchAction = () => {
-        message.success('批次操作完成');
-      };
-
-      const customActions = [
-        {
-          label: '設定',
-          icon: SettingOutlined && React.createElement(SettingOutlined),
-          tooltip: '設定選項',
-          onClick: () => message.info('開啟設定面板')
-        }
+    const MetricsOverview = () => {
+      const metrics = [
+        { label: 'ACTIVE INCIDENTS', value: '18', icon: '🔥' },
+        { label: 'SILENCE RULES', value: '42', icon: '🔕' },
+        { label: 'SERVICE HEALTH', value: '97.3%', icon: '🛡️' },
+        { label: 'ON-CALL ENGINEERS', value: '6', icon: '👩‍💻' }
       ];
 
       return (
-        <div style={{ padding: '16px 0' }}>
-          <ToolbarActions
-            onRefresh={handleRefresh}
-            onSearch={handleSearch}
-            onExport={handleExport}
-            onAdd={handleAdd}
-            onFilter={handleFilter}
-            onBatchAction={handleBatchAction}
-            filterActive={filterActive}
-            searchPlaceholder="搜尋事件、資源或規則..."
-            customActions={customActions}
-          />
-
-          <div style={{ marginTop: '16px', padding: '12px', background: 'rgba(24, 144, 255, 0.04)', borderRadius: '6px', border: '1px solid rgba(24, 144, 255, 0.2)' }}>
-            <p style={{ margin: 0, color: 'rgba(0, 0, 0, 0.65)', fontSize: '14px' }}>
-              {InfoCircleOutlined && React.createElement(InfoCircleOutlined, { style: { color: '#1890ff', marginRight: '8px' } })}
-              這是 SRE 平台的標準工具列組件，包含搜尋、篩選、匯出、新增等常用功能。
-              支援自訂按鈕、工具提示和回調函數。
-            </p>
-          </div>
-
-          <div style={{ marginTop: '24px', padding: '16px', background: 'rgba(0, 0, 0, 0.02)', borderRadius: '6px', border: '1px solid rgba(0, 0, 0, 0.06)' }}>
-            <h4 style={{ margin: '0 0 12px 0', fontSize: '14px', fontWeight: '600' }}>變體示例</h4>
-
-            <div style={{ marginBottom: '12px' }}>
-              <strong>簡潔版 (僅搜索和新增):</strong>
+        <div className="tag-stats-grid">
+          {metrics.map((item) => (
+            <div key={item.label} className="tag-stat-card glass-card-subtle">
+              <span className="tag-stat-icon">{item.icon}</span>
+              <span className="tag-stat-value">{item.value}</span>
+              <span className="tag-stat-label">{item.label}</span>
             </div>
-            <ToolbarActions
-              showRefresh={false}
-              showFilter={false}
-              showExport={false}
-              showBatchAction={false}
-              searchPlaceholder="快速搜索..."
-              customActions={[]}
-            />
-
-            <div style={{ marginTop: '16px', marginBottom: '12px' }}>
-              <strong>管理版 (包含所有功能):</strong>
-            </div>
-            <ToolbarActions
-              customActions={[
-                {
-                  label: '統計',
-                  icon: BarChartOutlined && React.createElement(BarChartOutlined),
-                  tooltip: '查看統計資料',
-                  onClick: () => message.info('開啟統計面板')
-                },
-                {
-                  label: '設定',
-                  icon: SettingOutlined && React.createElement(SettingOutlined),
-                  tooltip: '系統設定',
-                  onClick: () => message.info('開啟設定面板')
-                }
-              ]}
-            />
-          </div>
+          ))}
         </div>
       );
     };
 
-    const root12 = ReactDOM.createRoot(document.getElementById('demo-toolbar'));
-    root12.render(<ToolbarDemo />);
+    const ChartsSection = () => {
+      React.useEffect(() => {
+        const chartConfigs = [
+          {
+            id: 'chart-bar',
+            option: {
+              color: ['#1890ff', '#52c41a', '#faad14', '#ff4d4f'],
+              textStyle: { color: 'rgba(255,255,255,0.85)' },
+              tooltip: {
+                trigger: 'axis',
+                backgroundColor: '#1A1D23',
+                borderColor: 'rgba(255,255,255,0.12)'
+              },
+              grid: { left: '3%', right: '3%', bottom: '8%', containLabel: true },
+              xAxis: {
+                type: 'category',
+                data: ['00:00', '06:00', '12:00', '18:00', '24:00'],
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                axisLine: { lineStyle: { color: 'rgba(255,255,255,0.2)' } }
+              },
+              yAxis: {
+                type: 'value',
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                splitLine: { lineStyle: { color: 'rgba(255,255,255,0.08)' } }
+              },
+              series: [
+                {
+                  name: '事件數量',
+                  type: 'bar',
+                  data: [12, 22, 18, 26, 14],
+                  barWidth: 18,
+                  itemStyle: { borderRadius: [4, 4, 0, 0] }
+                }
+              ]
+            }
+          },
+          {
+            id: 'chart-pie',
+            option: {
+              color: ['#52c41a', '#faad14', '#ff4d4f', '#722ed1'],
+              tooltip: {
+                trigger: 'item',
+                backgroundColor: '#1A1D23',
+                borderColor: 'rgba(255,255,255,0.12)'
+              },
+              legend: {
+                top: 'bottom',
+                textStyle: { color: 'rgba(255,255,255,0.65)' }
+              },
+              series: [
+                {
+                  name: '健康狀態',
+                  type: 'pie',
+                  radius: ['40%', '70%'],
+                  avoidLabelOverlap: false,
+                  itemStyle: { borderColor: '#0A0B0E', borderWidth: 2 },
+                  label: {
+                    color: 'rgba(255,255,255,0.85)'
+                  },
+                  data: [
+                    { value: 62, name: '健康' },
+                    { value: 24, name: '警告' },
+                    { value: 9, name: '嚴重' },
+                    { value: 5, name: '維護中' }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            id: 'chart-line',
+            option: {
+              color: ['#1890ff'],
+              tooltip: {
+                trigger: 'axis',
+                backgroundColor: '#1A1D23',
+                borderColor: 'rgba(255,255,255,0.12)'
+              },
+              grid: { left: '3%', right: '3%', bottom: '8%', containLabel: true },
+              xAxis: {
+                type: 'category',
+                boundaryGap: false,
+                data: ['周一', '周二', '周三', '周四', '周五', '周六', '周日'],
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                axisLine: { lineStyle: { color: 'rgba(255,255,255,0.2)' } }
+              },
+              yAxis: {
+                type: 'value',
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                splitLine: { lineStyle: { color: 'rgba(255,255,255,0.08)' } }
+              },
+              series: [
+                {
+                  name: '平均修復時間 (分鐘)',
+                  type: 'line',
+                  smooth: true,
+                  areaStyle: {
+                    opacity: 0.2,
+                    color: new window.echarts.graphic.LinearGradient(0, 0, 0, 1, [
+                      { offset: 0, color: 'rgba(24, 144, 255, 0.4)' },
+                      { offset: 1, color: 'rgba(24, 144, 255, 0.05)' }
+                    ])
+                  },
+                  data: [16, 14, 12, 18, 11, 9, 13]
+                }
+              ]
+            }
+          },
+          {
+            id: 'chart-heatmap',
+            option: {
+              tooltip: {
+                position: 'top',
+                backgroundColor: '#1A1D23',
+                borderColor: 'rgba(255,255,255,0.12)'
+              },
+              grid: { height: '70%', top: '10%' },
+              xAxis: {
+                type: 'category',
+                data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                axisLine: { lineStyle: { color: 'rgba(255,255,255,0.2)' } }
+              },
+              yAxis: {
+                type: 'category',
+                data: ['API', 'DB', 'Storage', 'Network', 'CI/CD'],
+                axisLabel: { color: 'rgba(255,255,255,0.65)' },
+                axisLine: { lineStyle: { color: 'rgba(255,255,255,0.2)' } }
+              },
+              visualMap: {
+                min: 0,
+                max: 10,
+                calculable: true,
+                orient: 'horizontal',
+                left: 'center',
+                bottom: '2%',
+                textStyle: { color: 'rgba(255,255,255,0.85)' }
+              },
+              series: [{
+                name: '事件熱度',
+                type: 'heatmap',
+                data: [
+                  [0, 0, 2], [0, 1, 6], [0, 2, 4], [0, 3, 5], [0, 4, 3],
+                  [1, 0, 3], [1, 1, 7], [1, 2, 5], [1, 3, 6], [1, 4, 2],
+                  [2, 0, 5], [2, 1, 8], [2, 2, 6], [2, 3, 7], [2, 4, 4],
+                  [3, 0, 2], [3, 1, 4], [3, 2, 3], [3, 3, 5], [3, 4, 3],
+                  [4, 0, 1], [4, 1, 2], [4, 2, 2], [4, 3, 3], [4, 4, 1],
+                  [5, 0, 0], [5, 1, 1], [5, 2, 0], [5, 3, 2], [5, 4, 1],
+                  [6, 0, 1], [6, 1, 0], [6, 2, 1], [6, 3, 1], [6, 4, 0]
+                ],
+                label: { show: true, color: 'rgba(255,255,255,0.85)' },
+                itemStyle: {
+                  borderColor: 'rgba(255,255,255,0.05)'
+                }
+              }]
+            }
+          }
+        ];
 
-    // ECharts Demo
-    const initBarChart = () => {
-      const chart = echarts.init(document.getElementById('demo-bar'));
-      chart.setOption({
-        xAxis: { type: 'category', data: ['CPU', '記憶體', '磁碟'] },
-        yAxis: { type: 'value' },
-        series: [{ type: 'bar', data: [70, 45, 85], itemStyle: { color: '#1677ff' } }]
-      });
+        const instances = chartConfigs.map(({ id, option }) => {
+          const element = document.getElementById(id);
+          if (!element) return null;
+          const chart = window.echarts.init(element);
+          chart.setOption(option);
+          return chart;
+        }).filter(Boolean);
+
+        const handleResize = () => {
+          instances.forEach(chart => chart.resize());
+        };
+
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+          window.removeEventListener('resize', handleResize);
+          instances.forEach(chart => chart.dispose());
+        };
+      }, []);
+
+      return (
+        <div className="chart-grid">
+          <div id="chart-bar" className="chart-panel"></div>
+          <div id="chart-pie" className="chart-panel"></div>
+          <div id="chart-line" className="chart-panel"></div>
+          <div id="chart-heatmap" className="chart-panel"></div>
+        </div>
+      );
     };
-    const initPieChart = () => {
-      const chart = echarts.init(document.getElementById('demo-pie'));
-      chart.setOption({
-        series: [{
-          type: 'pie',
-          radius: '70%',
-          data: [
-            { value: 60, name: '健康' },
-            { value: 25, name: '警告' },
-            { value: 15, name: '嚴重' }
-          ]
-        }]
-      });
+
+    const DemoPage = () => {
+      const [form] = Form.useForm();
+      const [modalOpen, setModalOpen] = React.useState(false);
+      const [drawerOpen, setDrawerOpen] = React.useState(false);
+      const [filterActive, setFilterActive] = React.useState(false);
+
+      const tableData = React.useMemo(() => ([
+        {
+          key: 'rg-1',
+          group: '核心 API 服務',
+          status: 'healthy',
+          incidents: 2,
+          sla: '99.95%',
+          updatedAt: '2025-03-18 10:30'
+        },
+        {
+          key: 'rg-2',
+          group: '資料庫叢集',
+          status: 'warning',
+          incidents: 5,
+          sla: '99.60%',
+          updatedAt: '2025-03-18 10:12'
+        },
+        {
+          key: 'rg-3',
+          group: '服務網格',
+          status: 'healthy',
+          incidents: 1,
+          sla: '99.90%',
+          updatedAt: '2025-03-18 09:50'
+        },
+        {
+          key: 'rg-4',
+          group: '邊緣節點',
+          status: 'critical',
+          incidents: 7,
+          sla: '98.45%',
+          updatedAt: '2025-03-18 09:20'
+        },
+        {
+          key: 'rg-5',
+          group: 'CI/CD Pipeline',
+          status: 'warning',
+          incidents: 3,
+          sla: '99.10%',
+          updatedAt: '2025-03-18 08:55'
+        }
+      ]), []);
+
+      const tableColumns = React.useMemo(() => ([
+        {
+          title: '資源群組',
+          dataIndex: 'group',
+          key: 'group'
+        },
+        {
+          title: '健康狀態',
+          dataIndex: 'status',
+          key: 'status',
+          render: (status) => <StatusBadge status={status} />
+        },
+        {
+          title: '未關閉事件',
+          dataIndex: 'incidents',
+          key: 'incidents',
+          render: (value) => (
+            <Tag className={value > 4 ? 'ant-tag-red' : value > 2 ? 'ant-tag-orange' : 'ant-tag-blue'}>
+              {value} 件
+            </Tag>
+          )
+        },
+        {
+          title: 'SLA',
+          dataIndex: 'sla',
+          key: 'sla'
+        },
+        {
+          title: '最近更新',
+          dataIndex: 'updatedAt',
+          key: 'updatedAt'
+        },
+        {
+          title: '操作',
+          key: 'actions',
+          render: (_, record) => (
+            <TableRowActions
+              record={record}
+              onView={(item) => message.info(`查看 ${item.group}`)}
+              onEdit={(item) => message.success(`編輯 ${item.group}`)}
+              onDelete={(item) => message.warning(`刪除 ${item.group}`)}
+            />
+          )
+        }
+      ]), []);
+
+      const timelineItems = [
+        {
+          color: 'green',
+          children: <div><strong>10:25</strong> - 自動修復完成，健康狀態恢復</div>
+        },
+        {
+          color: 'blue',
+          children: <div><strong>09:58</strong> - 發佈新版本，觸發健康檢查</div>
+        },
+        {
+          color: 'red',
+          children: <div><strong>09:42</strong> - 偵測到 API 延遲上升，建立事件</div>
+        }
+      ];
+
+      const tabItems = [
+        {
+          key: 'tab1',
+          label: '事件分析',
+          children: <p style={{ margin: 0, color: 'var(--text-secondary)' }}>聚焦最近 24 小時事件趨勢，協助判斷是否需要擴大資源。</p>
+        },
+        {
+          key: 'tab2',
+          label: '容量指標',
+          children: <p style={{ margin: 0, color: 'var(--text-secondary)' }}>追蹤 CPU、記憶體、網路使用率，提供資源調整建議。</p>
+        },
+        {
+          key: 'tab3',
+          label: '變更紀錄',
+          children: <p style={{ margin: 0, color: 'var(--text-secondary)' }}>整合 GitOps 與配置變更歷程，快速追溯風險來源。</p>
+        }
+      ];
+
+      const handleFormSubmit = (values) => {
+        message.success('設定已送出');
+        form.resetFields();
+      };
+
+      return (
+        <div className="page-shell">
+          <header className="page-header">
+            <h1 className="page-title">SRE 平台 UI 元件規範</h1>
+            <p className="page-subtitle">此頁展示平台核心元件在實際暗色介面下的標準樣式，完全比照 prototype.html 的設計語言，作為實作與驗證的參考基準。</p>
+          </header>
+
+          <MetricsOverview />
+
+          <Section
+            title="標準操作按鈕"
+            description="PlatformButton 封裝了統一的高度、間距、圓角與互動效果，確保所有操作按鈕呈現一致體驗。"
+          >
+            <Space wrap size="middle">
+              <PlatformButton variant="primary" icon={<PlusOutlined />}>
+                建立事件
+              </PlatformButton>
+              <PlatformButton variant="secondary">
+                重新派單
+              </PlatformButton>
+              <PlatformButton variant="ghost" tooltip="切換快照">
+                生成快照
+              </PlatformButton>
+              <PlatformButton variant="text" icon={<SearchOutlined />}>
+                進階搜尋
+              </PlatformButton>
+              <PlatformButton variant="danger" icon={<DeleteOutlined />}>
+                強制終止
+              </PlatformButton>
+              <PlatformButton variant="primary" size="large" loading>
+                佈署中...
+              </PlatformButton>
+            </Space>
+          </Section>
+
+          <Section
+            title="工具列與表格"
+            description="整合 ToolbarActions 與 Ant Design Table，示範完整的資源群組總覽樣式，包含狀態徽章、操作列及分頁配置。"
+          >
+            <div className="table-wrapper">
+              <div className="table-toolbar">
+                <ToolbarActions
+                  onRefresh={() => message.success('已重新載入最新資料')}
+                  onExport={() => message.success('報表匯出成功')}
+                  onAdd={() => message.success('已建立新的資源群組')}
+                  onFilter={() => setFilterActive((prev) => !prev)}
+                  filterActive={filterActive}
+                  customActions={[
+                    {
+                      text: '批次刪除',
+                      variant: 'ghost',
+                      icon: <DeleteOutlined />,
+                      tooltip: '批次刪除選取項目',
+                      onClick: () => message.warning('請先選取需要刪除的項目')
+                    }
+                  ]}
+                />
+              </div>
+              <Table
+                columns={tableColumns}
+                dataSource={tableData}
+                pagination={{ pageSize: 5, showSizeChanger: false }}
+              />
+            </div>
+          </Section>
+
+          <Section
+            title="表單與彈出元件"
+            description="設定表單、Modal 與 Drawer 皆沿用統一的玻璃化樣式與邊框，提供一致的輸入體驗。"
+          >
+            <div className="form-layout">
+              <Form form={form} layout="vertical" onFinish={handleFormSubmit}>
+                <Form.Item
+                  label="資源群組名稱"
+                  name="groupName"
+                  rules={[{ required: true, message: '請輸入資源群組名稱' }]}
+                >
+                  <Input placeholder="例如：核心 API 服務" allowClear />
+                </Form.Item>
+                <Form.Item
+                  label="負責角色"
+                  name="owner"
+                  rules={[{ required: true, message: '請輸入主要負責角色' }]}
+                >
+                  <Input placeholder="例如：平台 On-Call" allowClear />
+                </Form.Item>
+                <Form.Item
+                  label="告警阈值 (ms)"
+                  name="threshold"
+                  rules={[{ required: true, message: '請設定觸發阈值' }]}
+                >
+                  <Input placeholder="例如：1200" suffix="ms" />
+                </Form.Item>
+                <Form.Item>
+                  <Space>
+                    <PlatformButton variant="primary" htmlType="submit">
+                      儲存設定
+                    </PlatformButton>
+                    <PlatformButton variant="text" onClick={() => form.resetFields()}>
+                      清除
+                    </PlatformButton>
+                  </Space>
+                </Form.Item>
+              </Form>
+
+              <Space direction="vertical" size="large">
+                <PlatformButton variant="primary" onClick={() => setModalOpen(true)}>
+                  開啟 Modal
+                </PlatformButton>
+                <PlatformButton variant="secondary" onClick={() => setDrawerOpen(true)}>
+                  開啟 Drawer
+                </PlatformButton>
+              </Space>
+            </div>
+
+            <Modal
+              title="靜音規則預覽"
+              open={modalOpen}
+              onCancel={() => setModalOpen(false)}
+              footer={null}
+            >
+              <p>此次靜音規則將套用於「核心 API 服務」，時間範圍為 02:00-05:00，涵蓋 3 條事件來源。</p>
+              <Space>
+                <PlatformButton variant="primary" onClick={() => { message.success('靜音規則建立成功'); setModalOpen(false); }}>
+                  確認建立
+                </PlatformButton>
+                <PlatformButton variant="text" onClick={() => setModalOpen(false)}>
+                  取消
+                </PlatformButton>
+              </Space>
+            </Modal>
+
+            <Drawer
+              title="資源診斷報告"
+              width={420}
+              open={drawerOpen}
+              onClose={() => setDrawerOpen(false)}
+            >
+              <p>自動蒐集最近 24 小時的事件、部署與健康度指標，並提供修復建議。</p>
+              <ul>
+                <li>服務網格延遲較基準值高出 18%</li>
+                <li>兩項部署於凌晨 01:00 完成，未觀察到錯誤</li>
+                <li>建議將 API 節流上限提升 10%</li>
+              </ul>
+            </Drawer>
+          </Section>
+
+          <Section
+            title="分頁與時間軸"
+            description="多分頁內容與時間軸事件沿用相同的暗色系配色，強調資訊層級。"
+          >
+            <Tabs items={tabItems} defaultActiveKey="tab1" />
+            <Timeline items={timelineItems} />
+          </Section>
+
+          <Section
+            title="描述與標籤"
+            description="Descriptions 與 Tag 使用統一的字級、邊距與底色，維持資訊呈現的一致性。"
+          >
+            <Descriptions bordered column={2} size="small">
+              <Descriptions.Item label="資源群組">核心 API 服務</Descriptions.Item>
+              <Descriptions.Item label="主要維運人員">林昱廷</Descriptions.Item>
+              <Descriptions.Item label="最近部署">2025-03-18 00:45</Descriptions.Item>
+              <Descriptions.Item label="地區">asia-east1</Descriptions.Item>
+              <Descriptions.Item label="備註" span={2}>所有事件皆已串接平台靜音規則與自動修復劇本。</Descriptions.Item>
+            </Descriptions>
+
+            <div className="tag-collection">
+              <Tag className="ant-tag-blue">API Gateway</Tag>
+              <Tag className="ant-tag-green">自動化修復</Tag>
+              <Tag className="ant-tag-orange">延遲警告</Tag>
+              <Tag className="ant-tag-red">高風險</Tag>
+            </div>
+          </Section>
+
+          <Section
+            title="ECharts 視覺化"
+            description="圖表區域沿用深色背景搭配高對比色彩，搭配玻璃化卡片呈現即時監控趨勢。"
+          >
+            <ChartsSection />
+          </Section>
+        </div>
+      );
     };
-    const initLineChart = () => {
-      const chart = echarts.init(document.getElementById('demo-line'));
-      chart.setOption({
-        xAxis: { type: 'category', data: ['00:00', '06:00', '12:00', '18:00'] },
-        yAxis: { type: 'value' },
-        series: [{ type: 'line', data: [20, 40, 35, 50], itemStyle: { color: '#52c41a' } }]
-      });
-    };
-    const initHeatmap = () => {
-      const chart = echarts.init(document.getElementById('demo-heatmap'));
-      const hours = ['00', '06', '12', '18'];
-      const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-      const data = [];
-      for (let i = 0; i < 5; i++) { for (let j = 0; j < 4; j++) { data.push([j, i, Math.round(Math.random() * 100)]) } }
-      chart.setOption({
-        tooltip: { position: 'top' },
-        xAxis: { type: 'category', data: hours },
-        yAxis: { type: 'category', data: days },
-        visualMap: { min: 0, max: 100, calculable: true, orient: 'horizontal', left: 'center', bottom: '5%' },
-        series: [{ type: 'heatmap', data }]
-      });
-    };
-    initBarChart();
-    initPieChart();
-    initLineChart();
-    initHeatmap();
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<DemoPage />);
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- rebuild the standalone demo page to use the prototype design tokens, glassmorphism layout, and dark theme foundations
- add the shared PlatformButton, ToolbarActions, table, form, and chart demonstrations so component styling matches the prototype implementation

## Testing
- not run (static demo page)

------
https://chatgpt.com/codex/tasks/task_e_68cfe6b515d0832d9067a6489b3c4019