### PR TITLE
feat: extend auth testing contract and schema

### DIFF
--- a/mock-server/server.js
+++ b/mock-server/server.js
@@ -2278,6 +2278,26 @@ app.put('/settings/auth', (req, res) => {
   Object.assign(authSettings, req.body || {}, { updated_at: toISO(new Date()) });
   res.json(authSettings);
 });
+
+app.post('/settings/auth/test', (req, res) => {
+  const executedAt = toISO(new Date());
+  const asyncMode = Boolean(req.body?.async);
+  const warnings = [];
+  if (!req.body?.test_username) {
+    warnings.push('未提供測試帳號，僅驗證 OIDC 端點可用性。');
+  }
+  const payload = {
+    status: asyncMode ? 'queued' : 'success',
+    executed_at: executedAt,
+    latency_ms: 128,
+    message: asyncMode
+      ? '已排入背景測試工作，完成後將以通知告知結果。'
+      : '身份驗證設定測試成功，能夠取得 access token。',
+    warnings,
+    trace_id: `oidc-test-${Date.now()}`
+  };
+  res.status(asyncMode ? 202 : 200).json(payload);
+});
 app.listen(PORT, () => {
   console.log(`Mock server listening on http://localhost:${PORT}`);
 });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3058,6 +3058,35 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /settings/auth/test:
+    post:
+      tags:
+        - 平台設定
+      summary: 測試身份驗證設定連線
+      operationId: testAuthSettings
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthTestRequest'
+      responses:
+        '200':
+          description: 測試結果摘要。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTestResult'
+        '202':
+          description: 測試請求已排入背景工作。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTestResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /tags/keys:
     get:
       tags:
@@ -5494,3 +5523,41 @@ components:
             client_secret:
               type: string
               format: password
+    AuthTestRequest:
+      type: object
+      properties:
+        settings_override:
+          $ref: '#/components/schemas/AuthSettingsRequest'
+        test_username:
+          type: string
+        test_password:
+          type: string
+          format: password
+        scope_override:
+          type: array
+          items:
+            type: string
+        async:
+          type: boolean
+          description: 是否以背景方式執行測試。
+    AuthTestResult:
+      type: object
+      required: [status, executed_at]
+      properties:
+        status:
+          type: string
+          enum: [success, failed, queued]
+        executed_at:
+          type: string
+          format: date-time
+        latency_ms:
+          type: integer
+        message:
+          type: string
+        warnings:
+          type: array
+          items:
+            type: string
+        trace_id:
+          type: string
+          nullable: true


### PR DESCRIPTION
## Summary
- add /settings/auth/test endpoint contract with reusable request and response schemas
- update database schema ordering, add resource_metrics table, move automation notification bridge, and include resend_available flag
- extend mock server to provide the new auth test endpoint responses for synchronous and async modes

## Testing
- npm start
- curl -s http://localhost:4000/settings/auth | jq '.provider'
- curl -s -X POST http://localhost:4000/settings/auth/test -H 'Content-Type: application/json' -d '{"test_username":"sre.tester"}' | jq
- curl -s -X POST http://localhost:4000/settings/auth/test -H 'Content-Type: application/json' -d '{"async":true}' | jq

------
https://chatgpt.com/codex/tasks/task_e_68d149eef9bc832d9ba61e9013b82788