### PR TITLE
Align system settings contract and mock data

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -50,6 +50,23 @@ CREATE TABLE team_subscribers (
 CREATE INDEX idx_team_subscribers_user ON team_subscribers (user_id);
 CREATE INDEX idx_team_subscribers_type ON team_subscribers (subscriber_type);
 
+CREATE TABLE user_invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(256) NOT NULL,
+    name VARCHAR(128),
+    status VARCHAR(32) NOT NULL DEFAULT 'invitation_sent',
+    invited_by UUID REFERENCES users(id),
+    invited_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    accepted_at TIMESTAMPTZ,
+    last_sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    token VARCHAR(256),
+    CONSTRAINT chk_user_invitations_status CHECK (status IN ('invitation_sent','accepted','expired','cancelled'))
+);
+CREATE UNIQUE INDEX idx_user_invitations_active_email ON user_invitations (email)
+    WHERE status = 'invitation_sent';
+CREATE INDEX idx_user_invitations_status ON user_invitations (status);
+
 CREATE TABLE roles (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(64) NOT NULL UNIQUE,

--- a/docs/contract-review-report.md
+++ b/docs/contract-review-report.md
@@ -8,16 +8,23 @@
 ## 2. API 契約檢查結果 (openapi.yaml)
 - **系統設定欄位不一致**：`SystemSettings` 以 `retention_policy` 物件表示保存天數，與資料庫的平坦欄位不符，亦缺少 `updated_by`。已改為 `retention_events_days`、`retention_logs_days`、`retention_metrics_days` 並標註 `updated_by`/`updated_at` 為唯讀欄位，同步更新 `/admin/settings` 的標籤分類為「平台設定」。
 - **團隊詳細資料**：沿用 `TeamDetail` 結構，確保詳細端點回傳訂閱者物件陣列 (`TeamSubscriber`) 並保留 `subscriber_ids`，以支援列表與詳細檢視之間的欄位映射。
+- **事件自動化對齊**：`EventDetail` 改以 `automation_executions` 回傳 `AutomationExecutionSummary` 陣列，對應 `automation_executions` 資料表的欄位，可支援 UI 呈現腳本名稱、狀態與起始時間。
+- **資源標籤統一**：`ResourceSummary`/`ResourceDetail`/`CreateResourceRequest` 的 `tags` 改為物件陣列 `{key,value}`，並移除混用的 `labels` 名稱，直接對應 `resource_labels` 的 key-value 結構。
+- **人員邀請流程**：移除 `POST /iam/users` 直建帳號端點，改新增 `POST /iam/invitations`，請求需帶 `email`/`name`，回應以 `invitation_sent` 狀態確認已觸發 Keycloak 邀請機制。
 
 ## 3. 資料庫結構檢查結果 (db_schema.sql)
 - 已包含 `resource_batch_operations`、`resource_batch_results`、`resource_scan_tasks`、`resource_scan_results` 對應資源批次操作與掃描流程；欄位含狀態、統計、錯誤訊息，符合原型需求。
 - `system_settings` 以平坦欄位存放維護模式、掃描限制與資料保留天數，對應更新後的 API 結構。
 - 事件、通知、儀表板、團隊與標籤等核心資料表均提供主鍵、外鍵、索引與檢查約束，支援前端 UI 所需的篩選與狀態統計。
+- 新增 `user_invitations` 表格，記錄邀請信箱、姓名、狀態與邀請者，並設置 `invitation_sent` 部分唯一索引，確保單一信箱僅有一筆有效邀請。
 
 ## 4. Mock Server 驗證結果 (mock-server/server.js)
 - 修正 `/dashboards` 建立路由未把新儀表板寫回記憶體陣列的問題，現可透過 GET 取得新建儀表板。
 - 新增 `buildTeamDetail` 工具，確保 `/iam/teams` 詳細與更新路由在處理物件化的 `subscribers` 時，同步維護 `subscriber_details`、`subscriber_ids` 與摘要所需的識別碼陣列。
 - `/admin/settings` 現回傳平坦欄位並在更新時自動平坦化舊版 `retention_policy` 結構，同時補上 `updated_by` 與最新的 `updated_at`。
+- `GET /events/{event_id}` 回傳 `automation_executions` 陣列；mock data 依事件篩選腳本執行紀錄，以支援前端自動化分頁。
+- 資源相關路由統一輸出 `{key,value}` 標籤並容忍舊版字串陣列輸入，mock data 與建立／更新流程皆走 `normalizeTags` 正規化。
+- 新增 `/iam/invitations` Mock 端點並移除建立人員路由，模擬邀請成功與缺漏 email 的錯誤回傳。
 
 ## 5. 測試與驗證 Testing
 - 於 `mock-server/` 執行 `npm install` 取得依賴後啟動 `npm start`，透過 `curl` 針對 `/dashboards`、`/iam/teams`、`/admin/settings` 進行 CRUD 流程驗證，確保回應符合 `openapi.yaml` 契約。
@@ -25,3 +32,4 @@
 ## 6. 待辦與建議 Next Steps
 - 後端實作時，需依據更新後的 `SystemSettings` 平坦欄位實作資料庫存取層，避免保留舊版 JSON 結構。
 - 若未來需要從訂閱者 ID 自動補齊顯示名稱，可考慮在 mock server 與正式服務加入查詢邏輯以產生 `subscriber_details` 完整資訊。
+- `POST /iam/invitations` 在串接 Keycloak 時需處理邀請信有效期限與重發節流，並回寫 `user_invitations` 表格。

--- a/docs/contract-review-report.md
+++ b/docs/contract-review-report.md
@@ -1,0 +1,27 @@
+# 契約檢查報告 Contract Review Report
+
+## 1. 檢查概覽 Overview
+- 參考 `docs/architecture.md`、`docs/specs.md` 與 `prototype.md` 建立事件管理、資源監控、儀表板、自動化、通知、設定等核心模組的 API 與資料模型清單。
+- 逐一對照 `openapi.yaml` 與 `db_schema.sql`，確認定義覆蓋 UI 所需欄位並符合 RESTful 慣例、分頁與錯誤回傳規範。
+- 實際啟動 `mock-server` 驗證 `/resources`、`/dashboards`、`/notification/*`、`/iam/*`、`/settings/*` 等端點的回應結構。
+
+## 2. API 契約檢查結果 (openapi.yaml)
+- **系統設定欄位不一致**：`SystemSettings` 以 `retention_policy` 物件表示保存天數，與資料庫的平坦欄位不符，亦缺少 `updated_by`。已改為 `retention_events_days`、`retention_logs_days`、`retention_metrics_days` 並標註 `updated_by`/`updated_at` 為唯讀欄位，同步更新 `/admin/settings` 的標籤分類為「平台設定」。
+- **團隊詳細資料**：沿用 `TeamDetail` 結構，確保詳細端點回傳訂閱者物件陣列 (`TeamSubscriber`) 並保留 `subscriber_ids`，以支援列表與詳細檢視之間的欄位映射。
+
+## 3. 資料庫結構檢查結果 (db_schema.sql)
+- 已包含 `resource_batch_operations`、`resource_batch_results`、`resource_scan_tasks`、`resource_scan_results` 對應資源批次操作與掃描流程；欄位含狀態、統計、錯誤訊息，符合原型需求。
+- `system_settings` 以平坦欄位存放維護模式、掃描限制與資料保留天數，對應更新後的 API 結構。
+- 事件、通知、儀表板、團隊與標籤等核心資料表均提供主鍵、外鍵、索引與檢查約束，支援前端 UI 所需的篩選與狀態統計。
+
+## 4. Mock Server 驗證結果 (mock-server/server.js)
+- 修正 `/dashboards` 建立路由未把新儀表板寫回記憶體陣列的問題，現可透過 GET 取得新建儀表板。
+- 新增 `buildTeamDetail` 工具，確保 `/iam/teams` 詳細與更新路由在處理物件化的 `subscribers` 時，同步維護 `subscriber_details`、`subscriber_ids` 與摘要所需的識別碼陣列。
+- `/admin/settings` 現回傳平坦欄位並在更新時自動平坦化舊版 `retention_policy` 結構，同時補上 `updated_by` 與最新的 `updated_at`。
+
+## 5. 測試與驗證 Testing
+- 於 `mock-server/` 執行 `npm install` 取得依賴後啟動 `npm start`，透過 `curl` 針對 `/dashboards`、`/iam/teams`、`/admin/settings` 進行 CRUD 流程驗證，確保回應符合 `openapi.yaml` 契約。
+
+## 6. 待辦與建議 Next Steps
+- 後端實作時，需依據更新後的 `SystemSettings` 平坦欄位實作資料庫存取層，避免保留舊版 JSON 結構。
+- 若未來需要從訂閱者 ID 自動補齊顯示名稱，可考慮在 mock server 與正式服務加入查詢邏輯以產生 `subscriber_details` 完整資訊。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2163,6 +2163,29 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+  /iam/invitations:
+    post:
+      tags:
+        - 身份與存取
+      summary: 發送人員邀請
+      operationId: createIamInvitation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateIAMInvitationRequest"
+      responses:
+        "201":
+          description: 邀請已發送。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IAMInvitationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
   /iam/users:
     get:
       tags:
@@ -2195,28 +2218,6 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/IAMUserSummary"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-    post:
-      tags:
-        - 身份與存取
-      summary: 建立人員帳號
-      operationId: createIamUser
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateIAMUserRequest"
-      responses:
-        "201":
-          description: 人員建立成功。
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IAMUserDetail"
-        "400":
-          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
   /iam/users/{user_id}:
@@ -3834,10 +3835,10 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/EventRelatedItem"
-            automation_actions:
+            automation_executions:
               type: array
               items:
-                type: string
+                $ref: "#/components/schemas/AutomationExecutionSummary"
             analysis:
               $ref: "#/components/schemas/EventAnalysisReport"
     EventTimelineEntry:
@@ -4125,6 +4126,14 @@ components:
           type: integer
         groups:
           type: integer
+    ResourceTag:
+      type: object
+      required: [key, value]
+      properties:
+        key:
+          type: string
+        value:
+          type: string
     ResourceSummary:
       type: object
       required:
@@ -4163,7 +4172,7 @@ components:
         tags:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/ResourceTag"
         last_event_count:
           type: integer
     CreateResourceRequest:
@@ -4188,14 +4197,10 @@ components:
           type: string
         os:
           type: string
-        labels:
-          type: array
-          items:
-            type: string
         tags:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/ResourceTag"
     UpdateResourceRequest:
       allOf:
         - $ref: "#/components/schemas/CreateResourceRequest"
@@ -4223,10 +4228,6 @@ components:
               type: string
               format: date-time
             groups:
-              type: array
-              items:
-                type: string
-            labels:
               type: array
               items:
                 type: string
@@ -4890,33 +4891,46 @@ components:
         last_login:
           type: string
           format: date-time
-    CreateIAMUserRequest:
+    UpdateIAMUserRequest:
       type: object
-      required: [username, name, email]
       properties:
-        username:
-          type: string
-        name:
-          type: string
-        email:
-          type: string
-          format: email
-        team_ids:
-          type: array
-          items:
-            type: string
         role_ids:
           type: array
           items:
             type: string
-    UpdateIAMUserRequest:
-      allOf:
-        - $ref: "#/components/schemas/CreateIAMUserRequest"
-        - type: object
-          properties:
-            status:
-              type: string
-              enum: [active, disabled]
+        team_ids:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [active, disabled]
+    CreateIAMInvitationRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+    IAMInvitationResponse:
+      type: object
+      required: [status, email, sent_at]
+      properties:
+        invitation_id:
+          type: string
+        status:
+          type: string
+          enum: [invitation_sent, accepted, expired, cancelled]
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        sent_at:
+          type: string
+          format: date-time
     IAMUserDetail:
       allOf:
         - $ref: "#/components/schemas/IAMUserSummary"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: SRE 平台 API 契約
-  version: 2.0.0
+  version: 3.0.0
   description: |
     定義 SRE 平台前端與後端之間的資料契約，涵蓋事件管理、資源監控、儀表板、
     自動化、通知、設定與個人偏好等模組。所有時間皆為 ISO 8601 格式 (UTC)。
@@ -3280,7 +3280,7 @@ paths:
   /admin/settings:
     get:
       tags:
-        - 系統管理
+        - 平台設定
       summary: 獲取系統設定
       operationId: getSystemSettings
       security:
@@ -3300,7 +3300,7 @@ paths:
           $ref: "#/components/responses/InternalError"
     post:
       tags:
-        - 系統管理
+        - 平台設定
       summary: 更新系統設定
       operationId: updateSystemSettings
       security:
@@ -4192,6 +4192,10 @@ components:
           type: array
           items:
             type: string
+        tags:
+          type: array
+          items:
+            type: string
     UpdateResourceRequest:
       allOf:
         - $ref: "#/components/schemas/CreateResourceRequest"
@@ -4228,6 +4232,10 @@ components:
                 type: string
             notes:
               type: string
+            silences:
+              type: array
+              items:
+                $ref: "#/components/schemas/SilenceRuleDetail"
     ResourceGroupSummary:
       type: object
       required: [group_id, name, member_count, subscriber_count]
@@ -5452,6 +5460,8 @@ components:
             type: string
         dry_run:
           type: boolean
+        note:
+          type: string
         started_at:
           type: string
           format: date-time
@@ -5987,6 +5997,14 @@ components:
                 type: string
     SystemSettings:
       type: object
+      required:
+        - maintenance_mode
+        - max_concurrent_scans
+        - auto_discovery_enabled
+        - alert_integration_enabled
+        - retention_events_days
+        - retention_logs_days
+        - retention_metrics_days
       properties:
         maintenance_mode:
           type: boolean
@@ -6000,21 +6018,23 @@ components:
         alert_integration_enabled:
           type: boolean
           default: true
-        retention_policy:
-          type: object
-          properties:
-            events_days:
-              type: integer
-              default: 90
-            logs_days:
-              type: integer
-              default: 30
-            metrics_days:
-              type: integer
-              default: 365
+        retention_events_days:
+          type: integer
+          default: 90
+        retention_logs_days:
+          type: integer
+          default: 30
+        retention_metrics_days:
+          type: integer
+          default: 365
+        updated_by:
+          type: string
+          nullable: true
+          readOnly: true
         updated_at:
           type: string
           format: date-time
+          readOnly: true
     SystemSettingsRequest:
       allOf:
         - $ref: "#/components/schemas/SystemSettings"


### PR DESCRIPTION
## Summary
- flatten the SystemSettings schema in openapi and update the admin settings tag to match the platform settings module
- update the mock server to persist created dashboards, preserve team subscriber details, and expose the new system settings shape
- add a contract review report capturing API/DB alignment and mock server validation results

## Testing
- npm install
- npm start (manual curl verification)


------
https://chatgpt.com/codex/tasks/task_e_68d197097180832d9906b1ef6b0ca3ad