### PR TITLE
Align notification contract details and enforce event-resource integrity

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -360,6 +360,15 @@ CREATE INDEX idx_resources_status ON resources (status);
 CREATE INDEX idx_resources_type ON resources (type);
 CREATE INDEX idx_resources_team ON resources (team_id);
 
+-- 建立事件與資源的外鍵關聯，確保事件參照有效資源
+ALTER TABLE events
+    ADD CONSTRAINT fk_events_resources
+    FOREIGN KEY (resource_id)
+    REFERENCES resources(id)
+    ON DELETE SET NULL;
+
+CREATE INDEX idx_events_resource ON events (resource_id);
+
 CREATE TABLE resource_labels (
     resource_id UUID NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
     label_key VARCHAR(128) NOT NULL,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6218,6 +6218,10 @@ components:
           enum: [user, team, role]
         id:
           type: string
+        display_name:
+          type: string
+          description: 對應接收者的顯示名稱，僅於回應中提供。
+          readOnly: true
     NotificationChannelRef:
       type: object
       required: [channel_id, channel_type]
@@ -6229,6 +6233,10 @@ components:
           enum: [Email, Slack, PagerDuty, Webhook, Teams, "LINE Notify", SMS]
         template:
           type: string
+        channel_name:
+          type: string
+          description: 通知管道的顯示名稱，僅於回應中提供。
+          readOnly: true
     NotificationStrategySummary:
       type: object
       required: [strategy_id, name, status]
@@ -6321,6 +6329,10 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/NotificationChannelRef"
+            severity_filters:
+              type: array
+              items:
+                type: string
             resource_filters:
               type: object
               additionalProperties: true


### PR DESCRIPTION
## Summary
- add display metadata for notification recipients/channels and expose severity filters in the OpenAPI contract
- enforce referential integrity between events and resources via a foreign key and supporting index
- enrich mock server notification strategy endpoints so responses match the updated contract

## Testing
- node --check mock-server/server.js

------
https://chatgpt.com/codex/tasks/task_e_68d229859104832da2636ab388cff781