### PR TITLE
Align mock server with updated API contract

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -18,10 +18,6 @@ CREATE TABLE users (
     avatar_url TEXT,
     -- 狀態
     status VARCHAR(32) NOT NULL DEFAULT 'active',
-    -- 語言
-    language VARCHAR(32) DEFAULT 'zh-TW',
-    -- 時區
-    timezone VARCHAR(64) DEFAULT 'Asia/Taipei',
     -- 最後登入時間
     last_login_at TIMESTAMPTZ,
     -- 建立時間
@@ -174,9 +170,9 @@ CREATE TABLE user_preferences (
     -- 預設頁面
     default_page VARCHAR(32) NOT NULL DEFAULT 'war_room',
     -- 語言
-    language VARCHAR(32) DEFAULT 'zh-TW',
+    language VARCHAR(32) NOT NULL DEFAULT 'zh-TW',
     -- 時區
-    timezone VARCHAR(64) DEFAULT 'Asia/Taipei',
+    timezone VARCHAR(64) NOT NULL DEFAULT 'Asia/Taipei',
     -- 通知偏好
     notification_preferences JSONB NOT NULL DEFAULT '{"email_notification":true,"slack_notification":false,"merge_notification":false}'::JSONB,
     -- 顯示選項

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4154,9 +4154,6 @@ components:
         read_at:
           type: string
           format: date-time
-        action:
-          type: string
-          description: 執行的快速操作名稱。
       oneOf:
         - required: [notification_ids]
         - required: [mark_all]


### PR DESCRIPTION
## Summary
- remove unused `language` and `timezone` fields from the `users` table and make their equivalents in `user_preferences` mandatory
- drop the unused `action` property from `NotificationReadRequest` in the OpenAPI contract
- overhaul the mock server to match the latest contract: introduce `/events/{event_id}/actions`, add `/analysis/capacity`, `/settings/widgets`, and `/settings/layouts`, rename notification management routes to `/notification-config/...`, and remove legacy admin/batch/toggle endpoints

## Testing
- node mock-server/server.js
- curl http://localhost:4000/analysis/capacity
- curl http://localhost:4000/events/evt-001/actions -X POST -H 'Content-Type: application/json' -d '{"action":"acknowledge","note":"確認處理","assignee_id":"user-001"}'
- curl http://localhost:4000/settings/widgets
- curl "http://localhost:4000/settings/layouts?page_path=%2Fwar-room"

------
https://chatgpt.com/codex/tasks/task_e_68d2869182fc832d80c5fb73644d5531