### PR TITLE
Fix API auth metadata and schema foreign keys

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -172,7 +172,7 @@ CREATE TABLE user_preferences (
     -- 系統頁面鍵值 (僅當類型為 system_page 時使用)
     default_home_page_key VARCHAR(64) DEFAULT 'war_room',
     -- 預設儀表板識別碼 (僅當類型為 dashboard 時使用)
-    default_dashboard_id UUID REFERENCES dashboards(id) ON DELETE SET NULL,
+    default_dashboard_id UUID,
     -- 語言
     language VARCHAR(32) NOT NULL DEFAULT 'zh-TW',
     -- 時區
@@ -671,7 +671,7 @@ CREATE TABLE resource_tags (
     -- 資源識別碼
     resource_id UUID NOT NULL REFERENCES resources(id) ON DELETE CASCADE,
     -- 標籤值識別碼
-    tag_value_id UUID NOT NULL REFERENCES tag_values(id) ON DELETE CASCADE,
+    tag_value_id UUID NOT NULL,
     -- 指派時間
     assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (resource_id, tag_value_id)
@@ -1002,6 +1002,12 @@ CREATE INDEX idx_dashboards_category ON dashboards (category);
 CREATE INDEX idx_dashboards_owner ON dashboards (owner_id);
 CREATE INDEX idx_dashboards_type ON dashboards (dashboard_type);
 CREATE UNIQUE INDEX idx_dashboards_grafana_uid ON dashboards (grafana_dashboard_uid) WHERE grafana_dashboard_uid IS NOT NULL;
+
+ALTER TABLE user_preferences
+    ADD CONSTRAINT fk_user_preferences_dashboard
+    FOREIGN KEY (default_dashboard_id)
+    REFERENCES dashboards(id)
+    ON DELETE SET NULL;
 
 CREATE TABLE dashboard_widgets (
     -- 主鍵識別碼
@@ -1396,6 +1402,12 @@ CREATE TABLE tag_values (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE UNIQUE INDEX idx_tag_values_unique ON tag_values (tag_id, value);
+
+ALTER TABLE resource_tags
+    ADD CONSTRAINT fk_resource_tags_tag_value
+    FOREIGN KEY (tag_value_id)
+    REFERENCES tag_values(id)
+    ON DELETE CASCADE;
 
 CREATE TABLE layout_widgets (
     -- 小工具識別碼

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -698,7 +698,11 @@ paths:
         依據 target_type 對事件或資源發起批次操作。當目標為資源時，僅允許團隊管理員或超級管理員執行。
       operationId: createBatchOperation
       security:
-        - bearerAuth: [team_member, team_manager, super_admin]
+        - bearerAuth: []
+      x-roles:
+        - team_member
+        - team_manager
+        - super_admin
       requestBody:
         required: true
         content:
@@ -734,7 +738,11 @@ paths:
       summary: 查詢批次處理狀態
       operationId: getBatchOperationStatus
       security:
-        - bearerAuth: [team_member, team_manager, super_admin]
+        - bearerAuth: []
+      x-roles:
+        - team_member
+        - team_manager
+        - super_admin
       responses:
         "200":
           description: 批次處理狀態與結果。
@@ -968,7 +976,11 @@ paths:
       summary: 產生事件彙總報告
       operationId: generateEventReport
       security:
-        - bearerAuth: [team_member, team_manager, super_admin]
+        - bearerAuth: []
+      x-roles:
+        - team_member
+        - team_manager
+        - super_admin
       requestBody:
         required: true
         content:
@@ -1670,7 +1682,10 @@ paths:
       summary: 啟動網路資源掃描
       operationId: scanResources
       security:
-        - bearerAuth: [team_manager, super_admin]
+        - bearerAuth: []
+      x-roles:
+        - team_manager
+        - super_admin
       requestBody:
         required: true
         content:
@@ -1699,7 +1714,10 @@ paths:
       summary: 查詢掃描任務狀態
       operationId: getScanTask
       security:
-        - bearerAuth: [team_manager, super_admin]
+        - bearerAuth: []
+      x-roles:
+        - team_manager
+        - super_admin
       parameters:
         - $ref: "#/components/parameters/TaskIdParam"
       responses:
@@ -3638,6 +3656,11 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   parameters:
     PageParam:
       name: page


### PR DESCRIPTION
## Summary
- add a reusable bearerAuth security scheme and annotate role requirements with x-roles
- keep resource scan and batch APIs compliant by clearing invalid scope arrays
- move dashboard and tag foreign keys to post-create constraints to avoid migration ordering errors

## Testing
- node mock-server/server.js (manual verification via curl)

------
https://chatgpt.com/codex/tasks/task_e_68d2dc6df264832d9fcb180adb35fa32