### PR TITLE
Add toggle endpoints and fix silence rule FK

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -296,7 +296,7 @@ CREATE TABLE silence_rules (
     -- 適用範圍
     scope VARCHAR(32) NOT NULL,
     -- 關聯事件識別碼 (快速靜音)
-    event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+    event_id UUID,
     -- 開始時間
     starts_at TIMESTAMPTZ NOT NULL,
     -- 結束時間
@@ -405,6 +405,11 @@ CREATE INDEX idx_events_rule_uid ON events (grafana_rule_uid);
 CREATE INDEX idx_events_source_status_time ON events (event_source, status, trigger_time DESC);
 COMMENT ON TABLE events IS '事件增值處理資料表，專注於 AI 分析、關聯分析與處理追蹤，不承載告警規則管理邏輯。';
 
+ALTER TABLE silence_rules
+    ADD CONSTRAINT fk_silence_rules_event
+    FOREIGN KEY (event_id)
+    REFERENCES events(id)
+    ON DELETE CASCADE;
 
 CREATE TABLE event_tags (
     -- 事件識別碼

--- a/mock-server/server.js
+++ b/mock-server/server.js
@@ -3411,7 +3411,14 @@ app.delete('/event-rules/:rule_uid', (req, res) => {
 app.post('/event-rules/:rule_uid/toggle', (req, res) => {
   const rule = getEventRuleByUid(req.params.rule_uid);
   if (!rule) return notFound(res, '找不到事件規則');
-  rule.enabled = !rule.enabled;
+  const payload = req.body || {};
+  if (typeof payload.enabled === 'boolean') {
+    rule.enabled = payload.enabled;
+  } else if (typeof payload.status === 'string') {
+    rule.enabled = payload.status.toLowerCase() === 'enabled';
+  } else {
+    rule.enabled = !rule.enabled;
+  }
   rule.last_updated = toISO(new Date());
   rule.last_synced_at = toISO(new Date());
   rule.sync_status = 'fresh';
@@ -4024,7 +4031,15 @@ app.delete('/automation/schedules/:schedule_id', (req, res) => {
 app.post('/automation/schedules/:schedule_id/toggle', (req, res) => {
   const schedule = getScheduleById(req.params.schedule_id);
   if (!schedule) return notFound(res, '找不到排程');
-  schedule.status = schedule.status === 'enabled' ? 'disabled' : 'enabled';
+  const payload = req.body || {};
+  if (typeof payload.enabled === 'boolean') {
+    schedule.status = payload.enabled ? 'enabled' : 'disabled';
+  } else if (typeof payload.status === 'string') {
+    schedule.status = payload.status.toLowerCase() === 'disabled' ? 'disabled' : 'enabled';
+  } else {
+    schedule.status = schedule.status === 'enabled' ? 'disabled' : 'enabled';
+  }
+  schedule.updated_at = toISO(new Date());
   res.json(schedule);
 });
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1189,6 +1189,32 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+  /event-rules/{rule_uid}/toggle:
+    post:
+      tags:
+        - 事件規則
+      summary: 切換事件規則啟用狀態
+      operationId: toggleEventRule
+      description: |-
+        切換或直接設定事件規則的啟用狀態。若未提供 payload，則反轉目前狀態；
+        若提供 `enabled` 欄位則依指定值更新。
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToggleEnabledRequest"
+      responses:
+        "200":
+          description: 更新後的事件規則資訊。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventRuleDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /event-rules/{rule_uid}/test:
     post:
       tags:
@@ -2305,6 +2331,32 @@ paths:
       responses:
         "204":
           description: 排程已刪除。
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /automation/schedules/{schedule_id}/toggle:
+    post:
+      tags:
+        - 自動化
+      summary: 切換自動化排程狀態
+      operationId: toggleAutomationSchedule
+      description: |-
+        切換或直接指定排程的 `status`。若 payload 內提供 `enabled` 或 `status` 值，
+        將依指定狀態更新；若無 payload 則在 enabled/disabled 間反轉。
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToggleEnabledRequest"
+      responses:
+        "200":
+          description: 更新後的排程資訊。
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationScheduleDetail"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -5035,6 +5087,17 @@ components:
       $ref: "#/components/schemas/EventRulePayload"
     UpdateEventRuleRequest:
       $ref: "#/components/schemas/EventRulePayload"
+    ToggleEnabledRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: |-
+            為 true 時啟用目標資源，為 false 時停用；若未提供則改以 status 或反轉現有狀態。
+        status:
+          type: string
+          enum: [enabled, disabled]
+          description: 供自動化排程直接指定狀態使用，會同步更新 enabled 布林值。
     TestEventRuleRequest:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- fix the silence rule foreign key so it is added after the events table exists
- extend the OpenAPI contract with /event-rules/{rule_uid}/toggle and /automation/schedules/{schedule_id}/toggle plus a shared ToggleEnabledRequest schema
- update the mock server to accept explicit enabled/status payloads and document the latest contract review findings

## Testing
- node server.js (manual start to exercise endpoints)
- curl -s -X POST http://localhost:4000/event-rules/rule-001/toggle -H 'Content-Type: application/json' -d '{"enabled":false}'
- curl -s -X POST http://localhost:4000/event-rules/rule-001/toggle
- curl -s -X POST http://localhost:4000/automation/schedules/sch-001/toggle -H 'Content-Type: application/json' -d '{"enabled":false}'
- curl -s -X POST http://localhost:4000/automation/schedules/sch-001/toggle


------
https://chatgpt.com/codex/tasks/task_e_68d349a72de8832dbc971d1162832d7a