### PR TITLE
feat: align IAM invitation contract and schema

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -99,6 +99,9 @@ CREATE TABLE user_invitations (
 CREATE UNIQUE INDEX idx_user_invitations_active_email ON user_invitations (email)
     WHERE status = 'invitation_sent';
 CREATE INDEX idx_user_invitations_status ON user_invitations (status);
+CREATE INDEX idx_user_invitations_invited_at ON user_invitations (invited_at DESC);
+CREATE INDEX idx_user_invitations_last_sent_at ON user_invitations (last_sent_at DESC);
+CREATE INDEX idx_user_invitations_expires_at ON user_invitations (expires_at DESC);
 
 CREATE TABLE roles (
     -- 主鍵識別碼
@@ -1234,7 +1237,7 @@ CREATE TABLE automation_executions (
     -- 主鍵識別碼
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -- 腳本識別碼
-    script_id UUID NOT NULL REFERENCES automation_scripts(id) ON DELETE SET NULL,
+    script_id UUID REFERENCES automation_scripts(id) ON DELETE SET NULL,
     -- 排程識別碼
     schedule_id UUID REFERENCES automation_schedules(id) ON DELETE SET NULL,
     -- 觸發來源

--- a/docs/backend-contract-review.md
+++ b/docs/backend-contract-review.md
@@ -1,0 +1,41 @@
+# 後端契約檢查報告 Backend Contract Review
+
+## 檢查摘要 Summary
+- 完成對 `openapi.yaml`、`db_schema.sql` 與 `mock-server/server.js` 的交叉檢查，聚焦在身份與存取管理模組的邀請流程與人員資料欄位。
+- 針對發現的契約落差（缺少邀請列表 API、使用者欄位命名不一致、資料庫外鍵約束衝突）提出並落實修正方案。
+- 新增邀請查詢 API 及索引支援前端分頁、排序需求，並同步更新 Mock Server 以供前端立即驗證。
+
+## 詳細發現 Detailed Findings
+1. **缺少邀請列表 API**  
+   - **文件來源**：`specs.md` 第 7.1 節指出需要顯示「待處理邀請」等統計資料，但 `openapi.yaml` 僅提供 `POST /iam/invitations`。  
+   - **風險**：前端無法載入邀請清單與統計卡片，影響 IAM 介面。  
+   - **修正**：新增 `GET /iam/invitations`，支援狀態篩選、關鍵字搜尋與排序。  
+
+2. **使用者顯示名稱欄位不一致**  
+   - **文件來源**：`db_schema.sql` 使用 `display_name`，而 `openapi.yaml` 的 `IAMUserSummary` 僅定義 `name`。  
+   - **風險**：後端回傳欄位與前端型別不符，導致 UI 顯示錯誤。  
+   - **修正**：將 `openapi.yaml` 內的 `IAMUserSummary` 調整為 `display_name`，並同步更新 Mock Server 回傳欄位。  
+
+3. **自動化執行歷史外鍵約束不一致**  
+   - **文件來源**：`db_schema.sql` 將 `automation_executions.script_id` 設為 `NOT NULL`，但同時宣告 `ON DELETE SET NULL`。  
+   - **風險**：當腳本被刪除時資料庫會嘗試寫入 NULL 造成約束衝突，歷史資料無法保留。  
+   - **修正**：移除 `NOT NULL` 約束，允許保留歷史紀錄並在 API schema 中將 `script_id` 標記為可為空值。  
+
+## 資料庫調整 Database Adjustments
+- `automation_executions.script_id` 移除 `NOT NULL`，確保 `ON DELETE SET NULL` 能正常運作。
+- `user_invitations` 新增 `invited_at`、`last_sent_at`、`expires_at` 索引，支援前端常用排序。
+
+## API 契約調整 API Contract Updates
+- 新增 `GET /iam/invitations` 端點與對應查詢參數說明。
+- `IAMInvitationResponse` 擴充欄位：`invited_by`、`invited_by_name`、`invited_at`、`expires_at`、`accepted_at`、`last_sent_at`。
+- `IAMUserSummary` 以 `display_name` 取代 `name`，避免欄位對應錯誤。
+
+## Mock Server 驗證 Mock Server Validation
+- 補上邀請列表資料與 API 實作，支援分頁、篩選與排序。
+- 確保 `POST /iam/invitations` 回傳最新欄位並維持資料一致性。
+- 語法驗證：`node --check mock-server/server.js`。
+
+## 後續建議 Next Steps
+- 於前端整合 `GET /iam/invitations` 以實作待處理邀請小工具與列表頁。
+- 為邀請 API 補強重新發送／取消等操作（若前端有需求）。
+- 監控 `automation_executions` 與 `user_invitations` 查詢效能，視實際資料量調整索引策略。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2443,6 +2443,57 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
   /iam/invitations:
+    get:
+      tags:
+        - 身份與存取
+      summary: 取得邀請列表
+      operationId: listIamInvitations
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/PageSizeParam"
+        - in: query
+          name: status
+          description: 依邀請狀態篩選，多個狀態以逗號分隔。
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [invitation_sent, accepted, expired, cancelled]
+        - in: query
+          name: keyword
+          description: 依電子郵件或姓名關鍵字模糊搜尋。
+          schema:
+            type: string
+        - in: query
+          name: sort_by
+          description: 指定排序欄位，預設為 invited_at。
+          schema:
+            type: string
+            enum: [invited_at, expires_at, email, status, last_sent_at]
+        - in: query
+          name: sort_order
+          description: 排序方向，支援 asc 或 desc，預設為 desc。
+          schema:
+            type: string
+            enum: [asc, desc]
+      responses:
+        "200":
+          description: 邀請列表。
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/IAMInvitationResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags:
         - 身份與存取
@@ -4998,6 +5049,7 @@ components:
           type: boolean
         script_id:
           type: string
+          nullable: true
         parameters:
           type: object
           additionalProperties: true
@@ -6203,6 +6255,7 @@ components:
           type: string
         script_id:
           type: string
+          nullable: true
         script_name:
           type: string
         status:
@@ -6250,13 +6303,13 @@ components:
           type: boolean
     IAMUserSummary:
       type: object
-      required: [user_id, username, name, email, status]
+      required: [user_id, username, display_name, email, status]
       properties:
         user_id:
           type: string
         username:
           type: string
-        name:
+        display_name:
           type: string
         email:
           type: string
@@ -6300,7 +6353,7 @@ components:
           type: string
     IAMInvitationResponse:
       type: object
-      required: [status, email, sent_at]
+      required: [invitation_id, status, email, invited_at, last_sent_at]
       properties:
         invitation_id:
           type: string
@@ -6312,7 +6365,27 @@ components:
           format: email
         name:
           type: string
-        sent_at:
+          nullable: true
+        invited_by:
+          type: string
+          nullable: true
+          description: 發送邀請者的使用者識別碼。
+        invited_by_name:
+          type: string
+          nullable: true
+          description: 發送邀請者的顯示名稱，供列表顯示。
+        invited_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        accepted_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_sent_at:
           type: string
           format: date-time
     IAMUserDetail:


### PR DESCRIPTION
## Summary
- add GET /iam/invitations to the OpenAPI contract and expand the invitation response payload
- align IAM user summaries with display_name and allow automation execution script references to be nullable
- refresh the mock server data/endpoints and document the backend contract audit findings

## Testing
- node --check mock-server/server.js

------
https://chatgpt.com/codex/tasks/task_e_68d34d947df4832da0bb67bf70d207a4