### PR TITLE
Add incident notes support across contracts and mock server

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -371,6 +371,8 @@ CREATE TABLE events (
     source VARCHAR(100),
     -- 服務影響
     service_impact TEXT,
+    -- 備註
+    notes TEXT,
     -- 資源識別碼
     resource_id UUID,
     -- Grafana 告警規則 UID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4648,6 +4648,9 @@ components:
           format: date-time
         assignee_id:
           type: string
+        notes:
+          type: string
+          description: 事件備註說明，通常由人工填寫補充資訊。
         metadata:
           type: object
           additionalProperties: true
@@ -4674,6 +4677,7 @@ components:
           format: date-time
         notes:
           type: string
+          description: 更新事件備註內容，若傳入空字串則清除備註。
         source:
           type: string
         service_impact:
@@ -4771,6 +4775,10 @@ components:
               type: string
               format: date-time
               nullable: true
+            notes:
+              type: string
+              nullable: true
+              description: 事件備註內容。
             timeline:
               type: array
               items:


### PR DESCRIPTION
## Summary
- allow incidents to persist manual notes by adding a notes column to the events table
- expose the notes field through Create/UpdateEvent contracts and EventDetail responses
- update the mock server data and handlers so incident notes round-trip correctly

## Testing
- node mock-server/server.js

------
https://chatgpt.com/codex/tasks/task_e_68d352a34930832db11bb21b9a0739a6