### PR TITLE
Simplify auth and event rule contracts

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3614,62 +3614,6 @@ paths:
                 $ref: "#/components/schemas/AuthSettings"
         "401":
           $ref: "#/components/responses/Unauthorized"
-    put:
-      tags:
-        - 平台設定
-      summary: （已棄用）更新身份驗證設定
-      operationId: updateAuthSettings
-      deprecated: true
-      description: |-
-        設定改由 Keycloak 等身份供應商集中管理，此端點僅保留向後相容性並將變更轉交外部系統。
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthSettingsRequest"
-      responses:
-        "200":
-          description: 身份驗證設定已更新。
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthSettings"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-  /settings/auth/test:
-    post:
-      tags:
-        - 平台設定
-      summary: （已棄用）測試身份驗證設定連線
-      operationId: testAuthSettings
-      deprecated: true
-      description: 身份驗證測試請改於外部身份供應商執行，此端點僅回報既有設定的健康狀態。
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthTestRequest"
-      responses:
-        "200":
-          description: 測試結果摘要。
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthTestResult"
-        "202":
-          description: 測試請求已排入背景工作。
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthTestResult"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
   /settings/widgets:
     get:
       tags:
@@ -5022,10 +4966,18 @@ components:
                 $ref: "#/components/schemas/ConditionGroup"
             title_template:
               type: string
-            content_template:
-              type: string
-            automation:
-              $ref: "#/components/schemas/AutomationSetting"
+              content_template:
+                type: string
+              grafana_definition:
+                type: object
+                description: 快取的 Grafana 告警規則定義 JSON，當前端離線編輯時提供表單回填資料。
+                additionalProperties: true
+              grafana_metadata:
+                type: object
+                description: Grafana 定義的補充資訊（建立者、最後同步時間等）。
+                additionalProperties: true
+              automation:
+                $ref: "#/components/schemas/AutomationSetting"
     EventRulePayload:
       type: object
       required: [name, severity, condition_groups]
@@ -6524,37 +6476,44 @@ components:
           type: string
           format: email
           nullable: true
-    NotificationDeliveryRecipient:
-      type: object
-      required: [recipient_type, identifier]
-      properties:
-        recipient_type:
-          type: string
-          enum: [user, team, role, channel, external]
-        identifier:
-          type: string
-        display_name:
-          type: string
-        contact:
-          type: string
-        delivery_status:
-          type: string
-          enum: [delivered, pending, failed, unknown]
-        delivery_status_message:
-          type: string
-    NotificationRecipient:
-      type: object
-      required: [type, id]
-      properties:
-        type:
-          type: string
-          enum: [user, team, role]
-        id:
-          type: string
-        display_name:
-          type: string
-          description: 對應接收者的顯示名稱，僅於回應中提供。
-          readOnly: true
+      NotificationRecipientBase:
+        type: object
+        required: [type, id]
+        properties:
+          type:
+            type: string
+          id:
+            type: string
+          display_name:
+            type: string
+            nullable: true
+      NotificationDeliveryRecipient:
+        allOf:
+          - $ref: "#/components/schemas/NotificationRecipientBase"
+          - type: object
+            properties:
+              type:
+                type: string
+                enum: [user, team, role, channel, external]
+              contact:
+                type: string
+              delivery_status:
+                type: string
+                enum: [delivered, pending, failed, unknown]
+              delivery_status_message:
+                type: string
+      NotificationRecipient:
+        allOf:
+          - $ref: "#/components/schemas/NotificationRecipientBase"
+          - type: object
+            properties:
+              type:
+                type: string
+                enum: [user, team, role]
+              display_name:
+                type: string
+                description: 對應接收者的顯示名稱，僅於回應中提供。
+                readOnly: true
     NotificationChannelRef:
       type: object
       required: [channel_id, channel_type]
@@ -7199,92 +7158,55 @@ components:
             type: string
         preview_url:
           type: string
-    AuthSettings:
-      type: object
-      required: [provider, oidc_enabled, client_id, auth_url, token_url]
-      properties:
-        provider:
-          type: string
-        oidc_enabled:
-          type: boolean
-        managed_by:
-          type: string
-          enum: [keycloak, custom]
-          description: 指示設定由哪個外部系統維護。
-        read_only:
-          type: boolean
-          description: 為 true 時代表設定僅提供查詢資訊。
-        realm:
-          type: string
-        client_id:
-          type: string
-        client_secret_hint:
-          type: string
-        auth_url:
-          type: string
-        token_url:
-          type: string
-        userinfo_url:
-          type: string
-        redirect_uri:
-          type: string
-        logout_url:
-          type: string
-        scopes:
-          type: array
-          items:
+      AuthSettings:
+        type: object
+        required: [provider, oidc_enabled, managed_by, read_only]
+        properties:
+          provider:
             type: string
-        user_sync:
-          type: boolean
-        updated_at:
-          type: string
-          format: date-time
-    AuthSettingsRequest:
-      allOf:
-        - $ref: "#/components/schemas/AuthSettings"
-        - type: object
-          properties:
-            client_secret:
+          oidc_enabled:
+            type: boolean
+          managed_by:
+            type: string
+            enum: [keycloak, custom]
+            description: 指示設定由哪個外部系統維護。
+          read_only:
+            type: boolean
+            description: 為 true 時代表設定僅提供查詢資訊。
+          realm:
+            type: string
+            nullable: true
+          client_id:
+            type: string
+            nullable: true
+          client_secret_hint:
+            type: string
+            nullable: true
+          auth_url:
+            type: string
+            nullable: true
+          token_url:
+            type: string
+            nullable: true
+          userinfo_url:
+            type: string
+            nullable: true
+          redirect_uri:
+            type: string
+            nullable: true
+          logout_url:
+            type: string
+            nullable: true
+          scopes:
+            type: array
+            items:
               type: string
-              format: password
-    AuthTestRequest:
-      type: object
-      properties:
-        settings_override:
-          $ref: "#/components/schemas/AuthSettingsRequest"
-        test_username:
-          type: string
-        test_password:
-          type: string
-          format: password
-        scope_override:
-          type: array
-          items:
+          user_sync:
+            type: boolean
+          updated_at:
             type: string
-        async:
-          type: boolean
-          description: 是否以背景方式執行測試。
-    AuthTestResult:
-      type: object
-      required: [status, executed_at]
-      properties:
-        status:
-          type: string
-          enum: [success, failed, queued]
-        executed_at:
-          type: string
-          format: date-time
-        latency_ms:
-          type: integer
-        message:
-          type: string
-        warnings:
-          type: array
-          items:
-            type: string
-        trace_id:
-          type: string
-          nullable: true
+            format: date-time
+            nullable: true
     LayoutScopeType:
       type: string
       enum: [global, role, user]


### PR DESCRIPTION
## Summary
- inline Grafana rule definition and metadata inside `event_rule_configs` to remove the redundant snapshot table
- make the `/settings/auth` contract read-only and adjust the schema to reflect Keycloak-managed authentication
- reuse a shared notification recipient shape and expose cached Grafana definitions via `EventRuleDetail`

## Testing
- python - <<'PY'
import yaml
with open('openapi.yaml') as f:
    yaml.safe_load(f)
print('openapi loaded')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d398d652a4832daaba4bbb6843eaad