### PR TITLE
Add Docker stack for project dependencies

### DIFF
--- a/config/DOCKER_README.md
+++ b/config/DOCKER_README.md
@@ -18,20 +18,20 @@ git clone <repository-url>
 cd sre-platform
 
 # 啟動所有服務
-./docker-start.sh
+./start-docker.sh
 
 # 或手動啟動
-docker-compose up -d
+docker compose -f config/docker/docker-compose.yml up -d
 ```
 
 ### 停止環境
 
 ```bash
 # 停止所有服務
-docker-compose down
+docker compose -f config/docker/docker-compose.yml down
 
 # 停止並刪除資料卷
-docker-compose down -v
+docker compose -f config/docker/docker-compose.yml down -v
 ```
 
 ## 📋 服務總覽
@@ -89,23 +89,23 @@ KEYCLOAK_ADMIN_PASSWORD=admin
 
 ```bash
 # 查看服務狀態
-docker-compose ps
+docker compose -f config/docker/docker-compose.yml ps
 
 # 查看特定服務日誌
-docker-compose logs -f grafana
+docker compose -f config/docker/docker-compose.yml logs -f grafana
 
 # 查看所有服務健康狀態
-./docker-start.sh  # 會自動檢查服務狀態
+./start-docker.sh  # 會自動檢查服務狀態
 ```
 
 ### 手動健康檢查
 
 ```bash
 # PostgreSQL
-docker-compose exec postgres pg_isready -U postgres
+docker compose -f config/docker/docker-compose.yml exec postgres pg_isready -U postgres
 
 # Redis
-docker-compose exec redis redis-cli ping
+docker compose -f config/docker/docker-compose.yml exec redis redis-cli ping
 
 # VictoriaMetrics
 curl http://localhost:8481/health
@@ -134,14 +134,14 @@ Prometheus 會自動收集所有服務的指標：
 
 ```bash
 # 查看所有服務日誌
-docker-compose logs
+docker compose -f config/docker/docker-compose.yml logs
 
 # 查看特定服務日誌
-docker-compose logs -f postgres
-docker-compose logs -f keycloak
+docker compose -f config/docker/docker-compose.yml logs -f postgres
+docker compose -f config/docker/docker-compose.yml logs -f keycloak
 
 # 查看最近的錯誤日誌
-docker-compose logs --tail=100 | grep ERROR
+docker compose -f config/docker/docker-compose.yml logs --tail=100 | grep ERROR
 ```
 
 ## 🔒 安全注意事項
@@ -196,7 +196,7 @@ services:
 2. 查看具體服務的日誌：
 
 ```bash
-docker-compose logs <service_name>
+docker compose -f config/docker/docker-compose.yml logs <service_name>
 ```
 
 3. 確保沒有其他服務佔用相同端口
@@ -207,8 +207,8 @@ docker-compose logs <service_name>
 
 ```bash
 # 停止服務並刪除資料卷
-docker-compose down -v
+docker compose -f config/docker/docker-compose.yml down -v
 
 # 重新啟動
-docker-compose up -d
+docker compose -f config/docker/docker-compose.yml up -d
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -34,23 +34,23 @@ config/
 
 ```bash
 # 啟動服務
-docker-compose -f config/docker/docker-compose.yml up -d
+docker compose -f config/docker/docker-compose.yml up -d
 
 # 查看狀態
-docker-compose -f config/docker/docker-compose.yml ps
+docker compose -f config/docker/docker-compose.yml ps
 
 # 查看日誌
-docker-compose -f config/docker/docker-compose.yml logs -f
+docker compose -f config/docker/docker-compose.yml logs -f
 
 # 停止服務
-docker-compose -f config/docker/docker-compose.yml down
+docker compose -f config/docker/docker-compose.yml down
 ```
 
 ## ⚙️ 配置說明
 
 ### Docker Compose 配置 (`docker/docker-compose.yml`)
 
-- **服務定義**: 包含 8 個核心服務
+- **服務定義**: 包含 10 個核心依賴服務
 - **網路配置**: 使用 `sre-network` 自定義網路
 - **數據持久化**: 所有服務數據保存到 Docker 卷
 - **健康檢查**: 每個服務都有健康檢查配置
@@ -136,7 +136,7 @@ scrape_configs:
 
 ```bash
 # 查看具體錯誤
-docker-compose -f config/docker/docker-compose.yml logs <service_name>
+docker compose -f config/docker/docker-compose.yml logs <service_name>
 
 # 檢查端口衝突
 netstat -tlnp | grep :<port>
@@ -146,8 +146,8 @@ netstat -tlnp | grep :<port>
 
 ```bash
 # 重置所有數據卷
-docker-compose -f config/docker/docker-compose.yml down -v
-docker-compose -f config/docker/docker-compose.yml up -d
+docker compose -f config/docker/docker-compose.yml down -v
+docker compose -f config/docker/docker-compose.yml up -d
 ```
 
 #### 網路連接問題

--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -1,8 +1,11 @@
+version: "3.9"
+
 services:
   # PostgreSQL 資料庫
   postgres:
     image: postgres:15
     container_name: sre-postgres
+    restart: unless-stopped
     environment:
       POSTGRES_DB: sre_dev
       POSTGRES_USER: postgres
@@ -23,6 +26,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: sre-redis
+    restart: unless-stopped
     ports:
       - "6379:6379"
     volumes:
@@ -39,6 +43,7 @@ services:
   grafana:
     image: grafana/grafana:10.2.0
     container_name: sre-grafana
+    restart: unless-stopped
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
@@ -61,6 +66,7 @@ services:
   vmstorage:
     image: victoriametrics/vmstorage:v1.125.0-cluster
     container_name: sre-vmstorage
+    restart: unless-stopped
     ports:
       - "8400:8400"
       - "8401:8401"
@@ -83,6 +89,7 @@ services:
   vminsert:
     image: victoriametrics/vminsert:v1.125.0-cluster
     container_name: sre-vminsert
+    restart: unless-stopped
     ports:
       - "8480:8480"
     depends_on:
@@ -103,6 +110,7 @@ services:
   vmselect:
     image: victoriametrics/vmselect:v1.125.0-cluster
     container_name: sre-vmselect
+    restart: unless-stopped
     ports:
       - "8481:8481"
     depends_on:
@@ -123,6 +131,7 @@ services:
   prometheus:
     image: victoriametrics/vmagent:v1.125.0
     container_name: sre-prometheus
+    restart: unless-stopped
     ports:
       - "8429:8429"  # vmagent metrics
     volumes:
@@ -149,6 +158,11 @@ services:
   snmp-exporter:
     image: prom/snmp-exporter:v0.20.0
     container_name: sre-snmp-exporter
+    restart: unless-stopped
+    volumes:
+      - ../monitoring/snmp.yml:/etc/snmp_exporter/snmp.yml:ro
+    command:
+      - --config.file=/etc/snmp_exporter/snmp.yml
     ports:
       - "9116:9116"
     networks:
@@ -158,6 +172,7 @@ services:
   chromadb:
     image: chromadb/chroma:0.4.24
     container_name: sre-chromadb
+    restart: unless-stopped
     ports:
       - "8000:8000"
     environment:
@@ -177,6 +192,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.3
     container_name: sre-keycloak
+    restart: unless-stopped
     environment:
       KC_HOSTNAME: localhost
       KC_HTTP_ENABLED: true
@@ -196,7 +212,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    command: ["start-dev", "--import-realm"]
+    command:
+      - start-dev
+      - --import-realm
+      - --hostname-strict=false
     volumes:
       - ../../pkg/auth/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
     healthcheck:
@@ -205,50 +224,6 @@ services:
       timeout: 10s
       retries: 10
       start_period: 120s
-    networks:
-      - sre-network
-
-  # SRE 後端服務
-  backend:
-    build:
-      context: ../..
-      dockerfile: backend/Dockerfile
-    container_name: sre-backend
-    ports:
-      - "8080:8080"
-    environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - sre-network
-
-  # SRE 前端服務
-  frontend:
-    build:
-      context: ../..
-      dockerfile: frontend/Dockerfile
-    container_name: sre-frontend
-    ports:
-      - "3001:80"
-    depends_on:
-      - backend
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
     networks:
       - sre-network
 

--- a/pkg/auth/keycloak/realm-export.json
+++ b/pkg/auth/keycloak/realm-export.json
@@ -1,0 +1,165 @@
+{
+  "id": "sre-platform",
+  "realm": "sre-platform",
+  "enabled": true,
+  "displayName": "SRE 平台",
+  "displayNameHtml": "<strong>SRE 平台</strong>",
+  "internationalizationEnabled": true,
+  "defaultLocale": "zh-TW",
+  "accountTheme": "keycloak",
+  "loginTheme": "keycloak",
+  "emailTheme": "keycloak",
+  "adminTheme": "keycloak",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "accessTokenLifespan": 3600,
+  "roles": {
+    "realm": [
+      {
+        "name": "sre_admin",
+        "description": "SRE 平台系統管理員",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "sre-platform"
+      },
+      {
+        "name": "sre_operator",
+        "description": "SRE 平台日常操作人員",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "sre-platform"
+      }
+    ]
+  },
+  "groups": [
+    {
+      "name": "SRE-Admins",
+      "path": "/SRE-Admins",
+      "realmRoles": ["sre_admin"]
+    },
+    {
+      "name": "SRE-Operators",
+      "path": "/SRE-Operators",
+      "realmRoles": ["sre_operator"]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "平台",
+      "lastName": "管理員",
+      "email": "admin@sre-platform.local",
+      "credentials": [
+        {
+          "type": "password",
+          "temporary": false,
+          "value": "admin"
+        }
+      ],
+      "realmRoles": [
+        "sre_admin",
+        "offline_access",
+        "uma_authorization"
+      ],
+      "groups": ["/SRE-Admins"]
+    },
+    {
+      "username": "operator",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "SRE",
+      "lastName": "工程師",
+      "email": "operator@sre-platform.local",
+      "credentials": [
+        {
+          "type": "password",
+          "temporary": false,
+          "value": "operator"
+        }
+      ],
+      "realmRoles": [
+        "sre_operator",
+        "offline_access",
+        "uma_authorization"
+      ],
+      "groups": ["/SRE-Operators"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "sre-platform-frontend",
+      "name": "SRE 平台前端",
+      "description": "SRE 平台 Web 前端客戶端",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost:5173/*",
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:5173/*\nhttp://localhost:3000/*"
+      }
+    },
+    {
+      "clientId": "sre-platform-backend",
+      "name": "SRE 平台後端",
+      "description": "SRE 平台後端服務",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "redirectUris": ["http://localhost:8080/*"],
+      "secret": "backend-secret",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "attributes": {
+        "client.secret.creation.time": "0"
+      }
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "sre-default",
+      "description": "SRE 平台預設範圍",
+      "protocol": "openid-connect",
+      "attributes": {
+        "display.on.consent.screen": "true",
+        "include.in.token.scope": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "web-origins",
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "sre-default"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access"
+  ]
+}


### PR DESCRIPTION
## Summary
- reorganized the Docker Compose stack to focus on dependency services and added persistent configuration mounts and health options
- bundled a Keycloak realm export so the identity provider starts with sensible defaults
- refreshed the startup script and documentation to use the unified Compose command and document optional application services

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3ed0cca0c832dbaa964731ae12516